### PR TITLE
Ensure that install_github works easily for all

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ torchvision is an extension for [torch](https://github.com/mlverse/torch) provid
 torchvision is not currently on CRAN. You can install it from GitHub with:
 
 ``` r
-remotes::install_github("mlverse/torchvision")
+remotes::install_github("mlverse/torchvision@main")
 ```
 


### PR DESCRIPTION
Seems like the `main` branch causes problems when installing. At least with older version of `remote`. Maybe a good idea to add the `@main` for a while.