### PR TITLE
fix documentation

### DIFF
--- a/R/transforms-generics.R
+++ b/R/transforms-generics.R
@@ -108,8 +108,8 @@ transform_center_crop <- function(img, size) {
 #' @param padding (int or tuple or list): Padding on each border. If a single
 #'   int is provided this is used to pad all borders. If tuple of length 2 is
 #'   provided this is the padding on left/right and top/bottom respectively.
-#'   If a tuple of length 4 is provided this is the padding for the left, top,
-#'   right and bottom borders respectively.
+#'   If a tuple of length 4 is provided this is the padding for the left, right,
+#'   top and bottom borders respectively.
 #' @param fill (int or str or tuple): Pixel fill value for constant fill.
 #'   Default is 0. If a tuple of length 3, it is used to fill R, G, B channels
 #'   respectively. This value is only used when the padding_mode is constant.

--- a/man/transform_pad.Rd
+++ b/man/transform_pad.Rd
@@ -12,8 +12,8 @@ transform_pad(img, padding, fill = 0, padding_mode = "constant")
 \item{padding}{(int or tuple or list): Padding on each border. If a single
 int is provided this is used to pad all borders. If tuple of length 2 is
 provided this is the padding on left/right and top/bottom respectively.
-If a tuple of length 4 is provided this is the padding for the left, top,
-right and bottom borders respectively.}
+If a tuple of length 4 is provided this is the padding for the left, right,
+top and bottom borders respectively.}
 
 \item{fill}{(int or str or tuple): Pixel fill value for constant fill.
 Default is 0. If a tuple of length 3, it is used to fill R, G, B channels

--- a/man/transform_random_crop.Rd
+++ b/man/transform_random_crop.Rd
@@ -25,8 +25,8 @@ i.e, if height > width, then image will be rescaled to
 \item{padding}{(int or tuple or list): Padding on each border. If a single
 int is provided this is used to pad all borders. If tuple of length 2 is
 provided this is the padding on left/right and top/bottom respectively.
-If a tuple of length 4 is provided this is the padding for the left, top,
-right and bottom borders respectively.}
+If a tuple of length 4 is provided this is the padding for the left, right,
+top and bottom borders respectively.}
 
 \item{pad_if_needed}{(boolean): It will pad the image if smaller than the
 desired size to avoid raising an exception. Since cropping is done


### PR DESCRIPTION
The documentation indicates a different order from how the code proceeds - `left, top,right and bottom` vs `left, right, top and bottom`. To check:

```
x <- torch_randn(3, 10, 10)
o <- transform_pad(x, c(2,2,1,1))
o$size()
# [1]  3 12 14
```

(This is wrong in the Python documentation as well :-) - but the underlying https://pytorch.org/docs/stable/nn.functional.html#vision-functions has it correct)
