### PR TITLE
fix key-value off vggface2 and casia-webface

### DIFF
--- a/tools/convert-models.py
+++ b/tools/convert-models.py
@@ -60,8 +60,8 @@ models = {
   'fcn_resnet101_coco': 'https://download.pytorch.org/models/fcn_resnet101_coco-7ecb50ca.pth',
   'deeplabv3_resnet50_coco': 'https://download.pytorch.org/models/deeplabv3_resnet50_coco-cd0a2569.pth',
   'deeplabv3_resnet101_coco': 'https://download.pytorch.org/models/deeplabv3_resnet101_coco-586e9e4e.pth',
-  'vggface2': 'https://github.com/timesler/facenet-pytorch/releases/download/v2.2.9/20180408-102900-casia-webface.pt',
-  'casia-webface': 'https://github.com/timesler/facenet-pytorch/releases/download/v2.2.9/20180402-114759-vggface2.pt'
+  'casia-webface': 'https://github.com/timesler/facenet-pytorch/releases/download/v2.2.9/20180408-102900-casia-webface.pt',
+  'vggface2': 'https://github.com/timesler/facenet-pytorch/releases/download/v2.2.9/20180402-114759-vggface2.pt'
 }
 
 os.mkdir("models/")


### PR DESCRIPTION
I mistakenly switch the order of the keys on convert-models' list.

'casia-webface':
'vggface2': 
