### PR TITLE
add pruning tests on 4 models

### DIFF
--- a/tests/testthat/test-models-mobilenetv2.R
+++ b/tests/testthat/test-models-mobilenetv2.R
@@ -13,3 +13,16 @@ test_that("mobilenetv2 works", {
   expect_tensor_shape(out, c(1, 1000))
   expect_equal_to_r(out[1,1], -1.1959798336029053, tolerance = 1e-5) # value taken from pytorch
 })
+
+test_that("we can prune head of mobilenetv2 moels", {
+  mobilenet <- model_mobilenet_v2(pretrained=TRUE)
+
+  expect_error(prune <- nn_prune_head(mobilenet, 1), NA)
+  expect_true(inherits(prune, "nn_sequential"))
+  expect_equal(length(prune), 1)
+  expect_true(inherits(prune[[length(prune)]], "nn_sequential"))
+
+  input <- torch::torch_randn(1, 3, 256, 256)
+  out <- prune(input)
+  expect_tensor_shape(out, c(1, 1280, 8, 8))
+})

--- a/tests/testthat/test-models-resnet.R
+++ b/tests/testthat/test-models-resnet.R
@@ -173,3 +173,47 @@ test_that("wide_resnet101_2", {
   expect_tensor_shape(out, c(1, 1000))
 
 })
+
+test_that("we can prune head of resnet34 moels", {
+  resnet34 <- model_resnet34(pretrained=TRUE)
+
+  expect_error(prune <- nn_prune_head(resnet34, 1), NA)
+  # expect_true(inherits(prune, "nn_sequential"))
+  expect_equal(length(prune), 9)
+  expect_true(inherits(prune[[length(prune)]], "nn_adaptive_avg_pool2d"))
+
+  input <- torch::torch_randn(1, 3, 256, 256)
+  out <- prune(input)
+  expect_tensor_shape(out, c(1, 512, 1, 1))
+
+})
+
+test_that("we can prune head of resnet50 moels", {
+  resnet50 <- model_resnet50(pretrained=TRUE)
+
+  expect_error(prune <- nn_prune_head(resnet50, 1), NA)
+  expect_true(inherits(prune, "nn_sequential"))
+  expect_equal(length(prune), 9)
+  expect_true(inherits(prune[[length(prune)]], "nn_adaptive_avg_pool2d"))
+
+  input <- torch::torch_randn(1, 3, 256, 256)
+  out <- prune(input)
+  expect_tensor_shape(out, c(1, 2048, 1, 1))
+
+
+})
+
+test_that("we can prune head of resnext101 moels", {
+  resnext101 <- model_resnext101_32x8d(pretrained=TRUE)
+
+  expect_error(prune <- torch:::nn_prune_head(resnext101, 1), NA)
+  expect_true(inherits(prune, "nn_sequential"))
+  expect_equal(length(prune), 9)
+  expect_true(inherits(prune[[length(prune)]], "nn_adaptive_avg_pool2d"))
+
+  input <- torch::torch_randn(1, 3, 256, 256)
+  out <- prune(input)
+  expect_tensor_shape(out, c(1, 2048, 1, 1))
+
+
+})


### PR DESCRIPTION
Now that https://github.com/mlverse/torch/pull/819 is on cran, it's time to integrate the pruning test in the relevant packages.