### PR TITLE
Addition of EMNIST dataset for image classification (issue #129)

### DIFF
--- a/R/dataset-mnist.R
+++ b/R/dataset-mnist.R
@@ -276,11 +276,11 @@ emnist_dataset <- dataset(
     },
     images_file = function() {
       suffix <- if (self$train) "train" else "test"
-      file.path(self$raw_folder, sprintf("emnist-%s-images-idx3-ubyte", self$split, suffix))
+      file.path(self$raw_folder, sprintf("emnist-%s-%s-images-idx3-ubyte", self$split, suffix))
     },
     labels_file = function() {
       suffix <- if (self$train) "train" else "test"
-      file.path(self$raw_folder, sprintf("emnist-%s-labels-idx1-ubyte", self$split, suffix))
+      file.path(self$raw_folder, sprintf("emnist-%s-%s-labels-idx1-ubyte", self$split, suffix))
     }
   )
 )

--- a/tests/testthat/test-dataset-mnist.R
+++ b/tests/testthat/test-dataset-mnist.R
@@ -53,3 +53,46 @@ test_that("tests for the kmnist dataset", {
   expect_true((torch_max(i[[1]]) <= 1)$item())
   expect_named(i, c("x", "y"))
 })
+
+test_that("tests for the emnist dataset (all splits)", {
+
+  dir <- tempfile(fileext = "/")
+  splits <- c("byclass", "bymerge", "balanced", "letters", "digits", "mnist")
+  expected_lengths <- c(
+    byclass = 697932,
+    bymerge = 697932,
+    balanced = 112800,
+    letters = 88800,
+    digits = 240000,
+    mnist = 60000
+  )
+  expected_classes <- c(
+    byclass = 62,
+    bymerge = 47,
+    balanced = 47,
+    letters = 26,
+    digits = 10,
+    mnist = 10
+  )
+
+  for (split in splits) {
+
+    ds <- emnist_dataset(dir, split = split, download = TRUE)
+    i <- ds[1]
+
+    expect_equal(dim(i[[1]]), c(28, 28))
+    expect_true(i[[2]] >= 0 && i[[2]] < expected_classes[[split]])
+    expect_equal(length(ds), expected_lengths[[split]])
+
+    ds <- emnist_dataset(dir, split = split, transform = transform_to_tensor)
+    dl <- torch::dataloader(ds, batch_size = 32)
+    iter <- dataloader_make_iter(dl)
+    i <- dataloader_next(iter)
+
+    expect_tensor_shape(i[[1]], c(32, 1, 28, 28))
+    expect_tensor_shape(i[[2]], 32)
+    expect_true((torch_max(i[[1]]) <= 1)$item())
+    expect_named(i, c("x", "y"))
+  }
+
+})


### PR DESCRIPTION
**This PR adds support for the EMNIST dataset with full split coverage, using the same structure as the existing MNIST dataset. The implementation:**

- Inherits from `mnist_dataset`
- Supports all official EMNIST splits: `"byclass"`, `"bymerge"`, `"balanced"`, `"letters"`, `"digits"`, and `"mnist"`
- Selects the appropriate download URL and MD5 hash based on the chosen split
- Provides consistent labeling and transform support for each split
- Adds test coverage for all supported EMNIST splits

**Closes #129**
