### PR TITLE
Fix poor detection results and MPS crashing for Faster/Mask R-CNN (#316)

### DIFF
--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -24,13 +24,12 @@ rpn_head <- torch::nn_module(
 rpn_head_v2 <- torch::nn_module(
     "rpn_head_v2",
     initialize = function(in_channels, num_anchors = 3) {
-      # The pretrained checkpoint stacks two Conv2d → BatchNorm2d → ReLU
-      # blocks with bias disabled on the convolutions. Mirror that layout so
+      # The pretrained checkpoint stacks two Conv2d → ReLU
+      # blocks with bias enabled. Mirror that layout so
       # the parameter names and shapes line up with the weight file.
       block <- function() {
         nn_sequential(
-          nn_conv2d(in_channels, in_channels, kernel_size = 3, padding = 1, bias = FALSE),
-          nn_batch_norm2d(in_channels),
+          nn_conv2d(in_channels, in_channels, kernel_size = 3, padding = 1, bias = TRUE),
           nn_relu()
         )
       }
@@ -76,90 +75,151 @@ rpn_head_mobilenet <- torch::nn_module(
 
 
 #' @importFrom torch torch_meshgrid torch_stack torch_tensor torch_stack torch_zeros_like torch_max torch_float32
-generate_level_anchors <- function(h, w, stride, scales) {
-  # Grid centers
-  shift_x <- torch_arange(0.5, w - 0.5, 1.0) * stride
-  shift_y <- torch_arange(0.5, h - 0.5, 1.0) * stride
-  shifts <- torch_meshgrid(list(shift_x, shift_y), indexing = "xy")
-  shift_grid <- torch_stack(list(shifts[[1]], shifts[[2]], shifts[[1]], shifts[[2]]), dim = 3)$unsqueeze(3)  # [H, W, 1, 4]
+#
+# generate_level_anchors
+#
+# Builds all anchor boxes for one FPN level (pure R + torch).
+#
+# The pretrained Faster R-CNN weights were trained with:
+#   sizes  = 32, 64, 128, 256  (one per level, 4 levels)
+#   ratios = 0.5, 1.0, 2.0    (3 anchors per grid location)
+#
+# h, w       : feature map height and width
+# stride     : stride of this FPN level = image_size / feature_map_size
+# anchor_size: the single anchor size for this level (e.g. 64 for p3)
+# ratios     : aspect ratios, default c(0.5, 1.0, 2.0)
+#
+# Returns a CPU tensor of shape [H * W * 3, 4] in (x1, y1, x2, y2) image coords.
+generate_level_anchors <- function(h, w, stride,
+                                   anchor_size,
+                                   ratios = c(0.5, 1.0, 2.0)) {
+  # ---- base anchors at origin (plain R arithmetic) ----------------------
+  area <- anchor_size^2
+  ws   <- sqrt(area / ratios)    # width  for each ratio  [length 3]
+  hs   <- ws * ratios            # height for each ratio  [length 3]
 
-  # Anchor sizes (width/height)
-  # Example: square anchors per scale
-  anchor_sizes <- torch_tensor(scales) * stride  # [A]
-  anchor_widths <- anchor_sizes
-  anchor_heights <- anchor_sizes
+  # Each base anchor is (x1, y1, x2, y2) centered at (0,0)
+  # shape: [3, 4] as a plain R matrix
+  base <- cbind(-ws / 2, -hs / 2, ws / 2, hs / 2)   # [3, 4]
+  base_t <- torch_tensor(base, dtype = torch_float32())  # [3, 4]
 
-  # Create base anchors [A, 4] (xc, yc, w, h)
-  anchors <- torch_stack(list(
-    torch_zeros_like(anchor_sizes),
-    torch_zeros_like(anchor_sizes),
-    anchor_widths,
-    anchor_heights
-  ), dim = 1)  # [A, 4]
+  # ---- grid of cell centers in image coordinates ------------------------
+  # In R, torch_arange(a, b) is INCLUSIVE of b, so use w-1 to get exactly w values
+  cx <- (torch_arange(0L, as.integer(w) - 1L, dtype = torch_float32()) + 0.5) * stride  # [W]
+  cy <- (torch_arange(0L, as.integer(h) - 1L, dtype = torch_float32()) + 0.5) * stride  # [H]
 
-  # Expand to [H, W, A, 4]
-  anchors <- anchors$reshape(c(1, 1, -1, 4)) + shift_grid  # Broadcasting
-  anchors
+
+  g  <- torch_meshgrid(list(cy, cx), indexing = "ij")  # each [H, W]
+  # Flatten and stack into shifts [H*W, 4]: (cx, cy, cx, cy)
+  cy_flat <- g[[1]]$flatten()   # [H*W]
+  cx_flat <- g[[2]]$flatten()   # [H*W]
+  # unsqueeze to [N,1] then cat along dim 2 -> [N,4]
+  shifts  <- torch_cat(list(cx_flat$unsqueeze(2),
+                            cy_flat$unsqueeze(2),
+                            cx_flat$unsqueeze(2),
+                            cy_flat$unsqueeze(2)), dim = 2)  # [H*W, 4]
+
+
+  # ---- broadcast: [H*W, 1, 4] + [1, 3, 4] = [H*W, 3, 4] ---------------
+  all_anchors <- shifts$unsqueeze(2) + base_t$unsqueeze(1)
+
+  # flatten to [H*W*3, 4]
+  all_anchors$reshape(c(-1L, 4L))
 }
 
+
+# decode_boxes: apply predicted (dx,dy,dw,dh) deltas to reference anchor boxes
+# anchors: [N, 4]  (x1, y1, x2, y2)
+# deltas:  [N, 4]  (dx, dy, dw, dh)
+# returns: [N, 4]  decoded boxes in (x1, y1, x2, y2) format
 decode_boxes <- function(anchors, deltas) {
-  widths <- anchors[, 3] - anchors[, 1]
-  heights <- anchors[, 4] - anchors[, 2]
-  ctr_x <- anchors[, 1] + widths / 2
-  ctr_y <- anchors[, 2] + heights / 2
+  widths  <- anchors[, 3] - anchors[, 1]   # anchor widths
+  heights <- anchors[, 4] - anchors[, 2]   # anchor heights
+  ctr_x   <- anchors[, 1] + widths  / 2   # anchor center x
+  ctr_y   <- anchors[, 2] + heights / 2   # anchor center y
 
   dx <- deltas[, 1]
   dy <- deltas[, 2]
-  dw <- deltas[, 3]
-  dh <- deltas[, 4]
+  dw <- torch::torch_clamp(deltas[, 3], max = 4.135)  # clamp exp to avoid overflow
+  dh <- torch::torch_clamp(deltas[, 4], max = 4.135)
 
   pred_ctr_x <- ctr_x + dx * widths
   pred_ctr_y <- ctr_y + dy * heights
-  pred_w <- torch::torch_exp(dw) * widths
-  pred_h <- torch::torch_exp(dh) * heights
+  pred_w     <- torch::torch_exp(dw) * widths
+  pred_h     <- torch::torch_exp(dh) * heights
 
   x1 <- pred_ctr_x - pred_w / 2
   y1 <- pred_ctr_y - pred_h / 2
   x2 <- pred_ctr_x + pred_w / 2
   y2 <- pred_ctr_y + pred_h / 2
 
-  torch::torch_stack(list(x1, y1, x2, y2), dim = 2)
+  # Bug fix: was dim=2 which gave [N,1,4]; -1 (last dim) gives correct [N,4]
+  torch::torch_stack(list(x1, y1, x2, y2), dim = -1)
 }
 
 #' @importFrom torch nnf_grid_sample torch_empty
-generate_proposals <- function(features, rpn_out, image_size, strides, batch_idx,
-                               score_thresh = 0.05, nms_thresh = 0.7) {
-  device <- rpn_out$objectness[[1]]$device
+#
+# generate_proposals
+#
+# Runs the RPN: for each FPN level, generate anchors, decode predicted deltas,
+# score by objectness, then filter + NMS to get final region proposals.
+#
+# anchor_sizes: one size per FPN level (e.g. 32, 64, 128, 256 for 4 levels)
+#               must match what the pretrained RPN head was trained with.
+generate_proposals <- function(features, rpn_out, image_size, anchor_sizes, batch_idx,
+                               score_thresh = 0.0, nms_thresh = 0.7,
+                               pre_nms_top_n = 1000L, post_nms_top_n = 1000L) {
+  device       <- rpn_out$objectness[[1]]$device
   all_proposals <- torch_empty(0L, 4L, device = device)
-  all_scores <- torch_empty(0L, device = device)
+  all_scores    <- torch_empty(0L,     device = device)
 
   for (i in seq_along(features)) {
-    objectness <- rpn_out$objectness[[i]][batch_idx, , , ]
-    deltas <- rpn_out$bbox_deltas[[i]][batch_idx, , , ]
+    objectness <- rpn_out$objectness[[i]][batch_idx, , , ]  # [A, H, W]
+    deltas     <- rpn_out$bbox_deltas[[i]][batch_idx, , , ] # [A*4, H, W]
 
     c(a, h, w) %<-% objectness$shape
 
-    anchors <- generate_level_anchors(h, w, strides[[i]], scales = seq_len(a))
-    anchors <- anchors$reshape(c(-1, 4))  # [H*W*A, 4]
+    # stride of this FPN level = image_width / feature_map_width
+    stride <- as.integer(image_size[2]) / w
 
-    objectness <- objectness$sigmoid()$flatten() ## [H*W*A]
-    deltas <- deltas$permute(c(2, 3, 1))$reshape(c(-1, 4))  # [H*W*A, 4]
+    # generate anchors: [H*W*3, 4]  (3 aspect ratios per location)
+    anchors <- generate_level_anchors(h, w, stride,
+                                      anchor_size = anchor_sizes[[i]],
+                                      ratios = c(0.5, 1.0, 2.0))
+    anchors <- anchors$to(device = device)
+
+    objectness <- objectness$sigmoid()$flatten()            # [H*W*3]
+    deltas     <- deltas$permute(c(2, 3, 1))$reshape(c(-1, 4))  # [H*W*3, 4]
 
     proposals <- decode_boxes(anchors, deltas)
     proposals <- clip_boxes_to_image(proposals, image_size)
 
     all_proposals <- torch::torch_cat(list(all_proposals, proposals), dim = 1L)
-    all_scores <- torch::torch_cat(list(all_scores, objectness), dim = 1L)
+    all_scores    <- torch::torch_cat(list(all_scores, objectness),   dim = 1L)
   }
 
-  scores <- all_scores$flatten()
-  keep <- scores > score_thresh
+  # keep high-confidence proposals and suppress overlapping ones
+  scores    <- all_scores$flatten()
+  keep      <- scores > score_thresh
   proposals <- all_proposals[keep, ]
-  scores <- scores[keep]
+  scores    <- scores[keep]
+
+  if (proposals$shape[1] > pre_nms_top_n) {
+    topk      <- torch::torch_topk(scores, pre_nms_top_n)
+    keep_idx  <- topk[[2]]
+    proposals <- proposals[keep_idx, ]
+    scores    <- scores[keep_idx]
+  }
 
   if (proposals$shape[1] > 0) {
-    keep_idx <- nms(proposals, scores, nms_thresh)
+    keep_idx  <- nms(proposals, scores, nms_thresh)
     proposals <- proposals[keep_idx, ]
+    scores    <- scores[keep_idx]
+    
+    if (proposals$shape[1] > post_nms_top_n) {
+      proposals <- proposals[1:post_nms_top_n, ]
+      scores    <- scores[1:post_nms_top_n]
+    }
   } else {
     proposals <- torch_empty(c(0, 4), device = device, dtype = torch_float32())
   }
@@ -167,54 +227,119 @@ generate_proposals <- function(features, rpn_out, image_size, strides, batch_idx
   list(proposals = proposals)
 }
 
-roi_align <- function(feature_map, proposals, batch_idx, output_size = c(7L, 7L)) {
-  # A vectorized version of roi_align_stub for feature_map: [B, C, H, W] and proposals: [N, 4] (x1, y1, x2, y2)
-
+# roi_align_single_level
+#
+# Pools features for a set of proposals from ONE feature map level.
+#
+# feature_map  : [1, C, H_feat, W_feat]  — a single FPN level (already batch-selected)
+# proposals    : [N, 4]  in image coordinates (x1, y1, x2, y2)
+# spatial_scale: image_size / feature_map_size  (e.g. 1/4 for stride-4 level)
+# output_size  : e.g. c(7L, 7L)
+#
+# Returns [N, C, output_size[1], output_size[2]]
+roi_align_single_level <- function(feature_map, proposals,
+                                   spatial_scale = 1/4,
+                                   output_size   = c(7L, 7L)) {
   num_rois <- proposals$size(1)
   if (num_rois == 0) {
-    return(torch_empty(c(0, feature_map$size(2), output_size[1], output_size[2]), device = feature_map$device))
+    return(torch_empty(c(0, feature_map$size(2),
+                         output_size[1], output_size[2]),
+                       device = feature_map$device))
   }
 
   channels <- feature_map$size(2)
-  h_feat <- feature_map$size(3)
-  w_feat <- feature_map$size(4)
+  h_feat   <- feature_map$size(3)
+  w_feat   <- feature_map$size(4)
 
-  # Normalize coordinnates to match grid_sample [-1 et 1]
-  x1 <- (proposals[, 1] / (w_feat - 1) * 2) - 1
-  y1 <- (proposals[, 2] / (h_feat - 1) * 2) - 1
-  x2 <- (proposals[, 3] / (w_feat - 1) * 2) - 1
-  y2 <- (proposals[, 4] / (h_feat - 1) * 2) - 1
+  # Step 1: scale proposals from image space → feature-map space
+  boxes_fm <- proposals$to(dtype = torch_float()) * spatial_scale  # [N, 4]
 
-  # Create a grid of output_size
-  grid_y <- torch_linspace(0, 1, output_size[1], device = feature_map$device)
-  grid_x <- torch_linspace(0, 1, output_size[2], device = feature_map$device)
+  # Step 2: normalize feature-map coordinates to [-1, 1] for grid_sample
+  # Using align_corners = FALSE convention: pixel i covers [i, i+1) in feature space,
+  # so the center of the whole map spans [-1, 1] with formula: coord / size * 2 - 1
+  x1 <- boxes_fm[, 1] / w_feat * 2 - 1
+  y1 <- boxes_fm[, 2] / h_feat * 2 - 1
+  x2 <- boxes_fm[, 3] / w_feat * 2 - 1
+  y2 <- boxes_fm[, 4] / h_feat * 2 - 1
 
-  # Meshgrid to get relative coordiantes in [7, 7]
-  grids <- torch_meshgrid(list(grid_y, grid_x), indexing = "ij")
-  rel_y <- grids[[1]]
+  # Step 3: build a [N, out_h, out_w, 2] sampling grid
+  # Each ROI gets its own evenly-spaced grid between its (x1,y1) and (x2,y2)
+  rel   <- torch_linspace(0, 1, output_size[1], device = feature_map$device)  # [M]
+  grids <- torch_meshgrid(list(rel, rel), indexing = "ij")  # each [M, M]
+  rel_y <- grids[[1]]  # [out_h, out_w]
   rel_x <- grids[[2]]
 
-  # Linear interpolation for each ROI [N, 7, 7]
-  # x <- x1 + rel_x * (x2 - x1)
   sampling_x <- x1$view(c(-1, 1, 1)) + rel_x$view(c(1, output_size[1], output_size[2])) * (x2 - x1)$view(c(-1, 1, 1))
   sampling_y <- y1$view(c(-1, 1, 1)) + rel_y$view(c(1, output_size[1], output_size[2])) * (y2 - y1)$view(c(-1, 1, 1))
 
-  # Concat to get a grid of [N, 7, 7, 2]
-  grid <- torch_stack(list(sampling_x, sampling_y), dim = -1)
+  grid <- torch_stack(list(sampling_x, sampling_y), dim = -1)  # [N, out_h, out_w, 2]
 
-  # bilinear sampling
-  input_selected <- feature_map[batch_idx, , , ]$unsqueeze(1)$expand(c(num_rois, channels, h_feat, w_feat))
+  # Step 4: bilinear sample from the feature map
+  # expand feature_map [1, C, H, W] -> [N, C, H, W] cheaply
+  input_expanded <- feature_map$expand(c(num_rois, channels, h_feat, w_feat))
 
-  pooled_features <- nnf_grid_sample(
-    input_selected,
+  nnf_grid_sample(
+    input_expanded,
     grid,
-    mode = "bilinear",
-    padding_mode = "border",
+    mode          = "bilinear",
+    padding_mode  = "border",
     align_corners = FALSE
-  )
+  )  # [N, C, out_h, out_w]
+}
 
-  # Return [N, C, 7, 7]
-  pooled_features
+
+# roi_align_fpn
+#
+# Multi-scale ROI Align following the FPN paper (Lin et al. 2017).
+# Assigns each proposal to the FPN level whose stride best matches the proposal size,
+# then calls roi_align_single_level for each group.
+#
+# features : named list with elements "p2","p3","p4","p5"  — each [1, C, H_l, W_l]
+# proposals: [N, 4]  image coordinates
+# output_size: pooled spatial size, default c(7L, 7L)
+#
+# Returns [N, C, out_h, out_w]
+roi_align_fpn <- function(features, proposals, output_size = c(7L, 7L)) {
+  # Spatial scales for each FPN level (stride = 4, 8, 16, 32)
+  spatial_scales <- c(1/4, 1/8, 1/16, 1/32)
+  level_names    <- c("p2", "p3", "p4", "p5")
+
+  n_boxes    <- proposals$size(1)
+  c_channels <- features[[1]]$size(2)
+  out        <- torch_zeros(c(n_boxes, c_channels, output_size[1], output_size[2]),
+                            dtype  = features[[1]]$dtype,
+                            device = features[[1]]$device)
+
+  if (n_boxes == 0) return(out)
+
+  # Assign each proposal to a level based on its sqrt(area)
+  # Formula from FPN paper Eq.(1): level = floor(k0 + log2(sqrt(area) / 224))
+  # k0=4, clamped to [2, 5] → list index [1, 4]
+  ws <- proposals[, 3] - proposals[, 1]
+  hs <- proposals[, 4] - proposals[, 2]
+  ws[ws <= 0] <- 1
+  hs[hs <= 0] <- 1
+  area_sqrt   <- (ws * hs)$sqrt()
+  target_lvl  <- (torch_log2(area_sqrt / 224) + 4)$floor()
+  target_lvl  <- torch_clamp(target_lvl, min = 2, max = 5)  # clamp to levels 2-5
+  list_idx    <- (target_lvl - 2)$to(dtype = torch_long()) + 1L  # convert to 1-based index
+
+  for (lvl in 1:4) {
+    mask <- list_idx$eq(lvl)$squeeze()
+    idx  <- torch_nonzero(mask)$squeeze()
+    if (idx$numel() == 0) next
+    if (idx$dim() == 0) idx <- idx$unsqueeze(1)  # handle single-element
+
+    pooled_lvl <- roi_align_single_level(
+      feature_map   = features[[level_names[lvl]]],
+      proposals     = proposals[idx, , drop = FALSE],
+      spatial_scale = spatial_scales[lvl],
+      output_size   = output_size
+    )
+    out[idx, , , ] <- pooled_lvl
+  }
+
+  out
 }
 
 roi_heads_module <-  torch::nn_module(
@@ -247,8 +372,16 @@ roi_heads_module <-  torch::nn_module(
       )()
     },
     forward = function(features, proposals, batch_idx) {
-      feature_maps <- features[c("p2", "p3", "p4", "p5")]
-      pooled <- roi_align(feature_maps[[1]], proposals, batch_idx)
+      # Select the batch item from each feature level: [1, C, H, W]
+      feature_maps <- list(
+        p2 = features[["p2"]][batch_idx, , , , drop = FALSE],
+        p3 = features[["p3"]][batch_idx, , , , drop = FALSE],
+        p4 = features[["p4"]][batch_idx, , , , drop = FALSE],
+        p5 = features[["p5"]][batch_idx, , , , drop = FALSE]
+      )
+      # Multi-scale ROI pooling across all FPN levels
+      pooled <- roi_align_fpn(feature_maps, proposals, output_size = c(7L, 7L))
+      # Flatten [N, C, 7, 7] -> [N, C*7*7] then through the box head
       x <- self$box_head(pooled$flatten(start_dim = 2))
       self$box_predictor(x)
     }
@@ -294,7 +427,14 @@ roi_heads_module_v2 <- torch::nn_module(
       )()
     },
     forward = function(features, proposals, batch_idx) {
-      pooled <- roi_align(features[[1]], proposals, batch_idx)
+      # Select the batch item from each feature level: [1, C, H, W]
+      feature_maps <- list(
+        p2 = features[["p2"]][batch_idx, , , , drop = FALSE],
+        p3 = features[["p3"]][batch_idx, , , , drop = FALSE],
+        p4 = features[["p4"]][batch_idx, , , , drop = FALSE],
+        p5 = features[["p5"]][batch_idx, , , , drop = FALSE]
+      )
+      pooled <- roi_align_fpn(feature_maps, proposals, output_size = c(7L, 7L))
       x <- self$box_head(pooled$flatten(start_dim = 2))
       self$box_predictor(x)
     }
@@ -409,35 +549,44 @@ fasterrcnn_model <- torch::nn_module(
     },
 
     forward = function(images) {
-      features <- self$backbone(images)
-      rpn_out <- self$rpn(features)
+      features   <- self$backbone(images)
+      rpn_out    <- self$rpn(features)
+      device     <- images$device           # inherit device from input (MPS / CUDA / CPU)
 
       batch_size <- images$shape[1]
       image_size <- images$shape[3:4]
       final_results <- list()
 
       for (b in seq_len(batch_size)) {
-        props <- generate_proposals(features, rpn_out, image_size, c(4, 8, 16, 32),
-                                    batch_idx = b, score_thresh = self$score_thresh,
-                                    nms_thresh = self$nms_thresh)
+        props <- generate_proposals(features, rpn_out, image_size,
+                                    anchor_sizes = list(32, 64, 128, 256),
+                                    batch_idx = b)
 
         if (props$proposals$shape[1] == 0) {
           empty <- list(
-            boxes = torch_empty(c(0, 4)),
-            labels = torch_empty(c(0), dtype = torch::torch_long()),
-            scores = torch_empty(c(0))
+            boxes  = torch_empty(c(0, 4),  device = device),
+            labels = torch_empty(c(0), dtype = torch::torch_long(), device = device),
+            scores = torch_empty(c(0),      device = device)
           )
-          return(list(features = features, detections = list(empty)))
+          final_results[[b]] <- empty
+          next
         }
 
         detections <- self$roi_heads(features, props$proposals, batch_idx = b)
 
+        # Softmax over all 91 classes: [N, 91]
         scores <- torch::nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch::torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
 
-        box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
+        # Skip background (index 1 in R = class 0 in COCO) when finding best class.
+        # Slice columns 2:91 (the 90 foreground classes) then add 1 back to labels
+        # so they map to the original 91-class indexing.
+        fg_scores <- scores[, 2:self$num_classes]  # [N, 90] — foreground only
+        max_fg    <- torch::torch_max(fg_scores, dim = 2)
+        final_scores <- max_fg[[1]]                # highest foreground score
+        final_labels <- max_fg[[2]] + 1L           # shift back to 1-based 91-class space
+
+        # Pick the bounding-box deltas for the predicted class
+        box_reg    <- detections$boxes$view(c(-1, self$num_classes, 4))
         gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
         final_boxes <- box_reg$gather(2, gather_idx)$squeeze(2)
 
@@ -471,9 +620,9 @@ fasterrcnn_model <- torch::nn_module(
             final_scores <- final_scores[top_idx]
           }
         } else {
-          final_boxes <- torch_empty(c(0, 4))
-          final_labels <- torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch_empty(c(0))
+          final_boxes  <- torch_empty(c(0, 4), device = device)
+          final_labels <- torch_empty(c(0), dtype = torch::torch_long(), device = device)
+          final_scores <- torch_empty(c(0),    device = device)
         }
         final_results[[b]] <- list(
           boxes = final_boxes,
@@ -600,35 +749,40 @@ fasterrcnn_model_v2 <- torch::nn_module(
       self$roi_heads <- roi_heads_module_v2(num_classes = num_classes)
     },
     forward = function(images) {
-      features <- self$backbone(images)
-      rpn_out <- self$rpn(features)
+      features   <- self$backbone(images)
+      rpn_out    <- self$rpn(features)
+      device     <- images$device           # inherit device from input
 
       batch_size <- images$shape[1]
       image_size <- images$shape[3:4]
       final_results <- list()
 
       for (b in seq_len(batch_size)) {
-        props <- generate_proposals(features, rpn_out, image_size, c(4, 8, 16, 32),
-                                    batch_idx = b, score_thresh = self$score_thresh,
-                                    nms_thresh = self$nms_thresh)
+        props <- generate_proposals(features, rpn_out, image_size,
+                                    anchor_sizes = list(32, 64, 128, 256),
+                                    batch_idx = b)
 
         if (props$proposals$shape[1] == 0) {
           empty <- list(
-            boxes = torch_empty(c(0, 4)),
-            labels = torch_empty(c(0), dtype = torch::torch_long()),
-            scores = torch_empty(c(0))
+            boxes  = torch_empty(c(0, 4),  device = device),
+            labels = torch_empty(c(0), dtype = torch::torch_long(), device = device),
+            scores = torch_empty(c(0),      device = device)
           )
-          return(list(features = features, detections = list(empty)))
+          final_results[[b]] <- empty
+          next
         }
 
         detections <- self$roi_heads(features, props$proposals, batch_idx = b)
 
-        scores <- nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
+        scores    <- nnf_softmax(detections$scores, dim = 2)  # [N, 91]
 
-        box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
+        # Skip background class (column 1 = class 0) when picking the best label
+        fg_scores    <- scores[, 2:self$num_classes]  # [N, 90]
+        max_fg       <- torch_max(fg_scores, dim = 2)
+        final_scores <- max_fg[[1]]
+        final_labels <- max_fg[[2]] + 1L  # shift back to 91-class indexing
+
+        box_reg    <- detections$boxes$view(c(-1, self$num_classes, 4))
         gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
         final_boxes <- box_reg$gather(2, gather_idx)$squeeze(2)
 
@@ -662,9 +816,9 @@ fasterrcnn_model_v2 <- torch::nn_module(
             final_scores <- final_scores[top_idx]
           }
         } else {
-          final_boxes <- torch_empty(c(0, 4))
-          final_labels <- torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch_empty(c(0))
+          final_boxes  <- torch_empty(c(0, 4), device = device)
+          final_labels <- torch_empty(c(0), dtype = torch::torch_long(), device = device)
+          final_scores <- torch_empty(c(0),    device = device)
         }
         final_results[[b]] <- list(
           boxes = final_boxes,
@@ -761,35 +915,40 @@ fasterrcnn_mobilenet_model <- torch::nn_module(
       self$roi_heads <- roi_heads_module(num_classes = num_classes)
     },
     forward = function(images) {
-      features <- self$backbone(images)
-      rpn_out <- self$rpn(features)
+      features   <- self$backbone(images)
+      rpn_out    <- self$rpn(features)
+      device     <- images$device           # inherit device from input
 
       batch_size <- images$shape[1]
       image_size <- images$shape[3:4]
       final_results <- list()
 
       for (b in seq_len(batch_size)) {
-        props <- generate_proposals(features, rpn_out, image_size, c(8, 16),
-                                    batch_idx = b, score_thresh = self$score_thresh,
+        props <- generate_proposals(features, rpn_out, image_size,
+                                    anchor_sizes = list(64, 128),
+                                    batch_idx = b,
+                                    score_thresh = self$score_thresh,
                                     nms_thresh = self$nms_thresh)
 
         if (props$proposals$shape[1] == 0) {
           empty <- list(
-            boxes = torch_empty(c(0, 4)),
-            labels = torch_empty(c(0), dtype = torch::torch_long()),
-            scores = torch_empty(c(0))
+            boxes  = torch_empty(c(0, 4),  device = device),
+            labels = torch_empty(c(0), dtype = torch::torch_long(), device = device),
+            scores = torch_empty(c(0),      device = device)
           )
           return(list(features = features, detections = list(empty)))
         }
 
         detections <- self$roi_heads(features, props$proposals, batch_idx = b)
 
-        scores <- nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
+        scores    <- nnf_softmax(detections$scores, dim = 2)  # [N, 91]
 
-        box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
+        fg_scores    <- scores[, 2:self$num_classes]
+        max_fg       <- torch_max(fg_scores, dim = 2)
+        final_scores <- max_fg[[1]]
+        final_labels <- max_fg[[2]] + 1L
+
+        box_reg    <- detections$boxes$view(c(-1, self$num_classes, 4))
         gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
         final_boxes <- box_reg$gather(2, gather_idx)$squeeze(2)
 
@@ -821,9 +980,9 @@ fasterrcnn_mobilenet_model <- torch::nn_module(
             final_scores <- final_scores[top_idx]
           }
         } else {
-          final_boxes <- torch_empty(c(0, 4))
-          final_labels <- torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch_empty(c(0))
+          final_boxes  <- torch_empty(c(0, 4), device = device)
+          final_labels <- torch_empty(c(0), dtype = torch::torch_long(), device = device)
+          final_scores <- torch_empty(c(0), device = device)
         }
         final_results[[b]] <- list(
           boxes = final_boxes,
@@ -1060,10 +1219,8 @@ model_fasterrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE
       runtime_error("Corrupt file! Delete the file in {state_dict_path} and try again.")
     }
     state_dict <- torch::load_state_dict(state_dict_path)
-
+    state_dict <- .rename_fasterrcnn_v2_state_dict(state_dict)
     model_state <- model$state_dict()
-    # TODO remove that model scalping
-    # TODO will fail due to setdiff(names(model$modules), names(state_dict)), currently 221 discrepancies
     state_dict <- state_dict[names(state_dict) %in% names(model_state)]
     for (n in names(state_dict)) {
       if (!all(state_dict[[n]]$size() == model_state[[n]]$size())) {
@@ -1077,7 +1234,7 @@ model_fasterrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE
       }
     }
 
-    model$load_state_dict(state_dict, strict = TRUE)
+    model$load_state_dict(state_dict)
   }
 
   model
@@ -1178,6 +1335,22 @@ model_fasterrcnn_mobilenet_v3_large_320_fpn <- function(pretrained = FALSE,
     sub(pattern = "(body\\.0\\.)1\\.", replacement = "\\1bn\\.", x = .) %>%
     sub(pattern = "(body\\.16\\.)0\\.", replacement = "\\1conv\\.", x = .) %>%
     sub(pattern = "(body\\.16\\.)1\\.", replacement = "\\1bn\\.", x = .)
+
+  # Recreate a list with renamed keys
+  setNames(state_dict[names(state_dict)], new_names)
+}
+
+.rename_fasterrcnn_v2_state_dict <- function(state_dict) {
+  . <- NULL # Nulling strategy for no visible binding check Note
+  new_names <- names(state_dict) %>%
+    # Fix FPN Sequential nesting: Conv layers (PyTorch 0.0 -> R 0)
+    sub(pattern = "(inner_blocks\\.[0-3]\\.)0\\.0\\.", replacement = "\\10\\.", x = .) %>%
+    sub(pattern = "(layer_blocks\\.[0-3]\\.)0\\.0\\.", replacement = "\\10\\.", x = .) %>%
+    # BN layers (PyTorch 0.1 -> R 1)
+    sub(pattern = "(inner_blocks\\.[0-3]\\.)0\\.1\\.", replacement = "\\11\\.", x = .) %>%
+    sub(pattern = "(layer_blocks\\.[0-3]\\.)0\\.1\\.", replacement = "\\11\\.", x = .) %>%
+    # Fix Box Head final linear layer (PyTorch 5 -> R 4)
+    sub(pattern = "(roi_heads\\.box_head\\.)5\\.", replacement = "\\14\\.", x = .)
 
   # Recreate a list with renamed keys
   setNames(state_dict[names(state_dict)], new_names)

--- a/R/models-mask_rcnn.R
+++ b/R/models-mask_rcnn.R
@@ -104,12 +104,12 @@ mask_head_module_v2 <- torch::nn_module(
 #' @noRd
 roi_align_masks <- function(feature_map,
                             proposals,
-                            output_size = c(14L, 14L),
+                            output_size   = c(14L, 14L),
                             spatial_scale = 1.0,
                             sampling_ratio = 2L,
                             aligned = FALSE) {
 
-  # Scale the boxes to the feature map resolution
+  # Scale boxes from image coordinates to feature-map coordinates
   boxes_scaled <- proposals$to(dtype = torch_float())$mul(spatial_scale)
 
   num_rois <- boxes_scaled$size(1)
@@ -119,44 +119,41 @@ roi_align_masks <- function(feature_map,
   }
 
   channels <- feature_map$size(2)
-  h_feat <- feature_map$size(3)
-  w_feat <- feature_map$size(4)
+  h_feat   <- feature_map$size(3)
+  w_feat   <- feature_map$size(4)
 
-  # Normalize coordinates to match grid_sample [-1 to 1]
-  x1 <- (boxes_scaled[, 1] / (w_feat - 1) * 2) - 1
-  y1 <- (boxes_scaled[, 2] / (h_feat - 1) * 2) - 1
-  x2 <- (boxes_scaled[, 3] / (w_feat - 1) * 2) - 1
-  y2 <- (boxes_scaled[, 4] / (h_feat - 1) * 2) - 1
+  # Normalize to [-1, 1] using the align_corners=FALSE convention:
+  # pixel i occupies [i, i+1), so divide by the total extent (h_feat or w_feat)
+  x1 <- boxes_scaled[, 1] / w_feat * 2 - 1
+  y1 <- boxes_scaled[, 2] / h_feat * 2 - 1
+  x2 <- boxes_scaled[, 3] / w_feat * 2 - 1
+  y2 <- boxes_scaled[, 4] / h_feat * 2 - 1
 
-  # Create a grid of output_size
-  grid_y <- torch_linspace(0, 1, output_size[1], device = feature_map$device)
-  grid_x <- torch_linspace(0, 1, output_size[2], device = feature_map$device)
-
-  # Meshgrid to get relative coordinates
-  grids <- torch_meshgrid(list(grid_y, grid_x), indexing = "ij")
+  # Build a relative coordinate grid [0, 1] for the output resolution
+  rel   <- torch_linspace(0, 1, output_size[1], device = feature_map$device)
+  grids <- torch_meshgrid(list(rel, rel), indexing = "ij")
   rel_y <- grids[[1]]
   rel_x <- grids[[2]]
 
-  # Linear interpolation for each ROI [N, output_size[1], output_size[2]]
+  # Interpolated sampling positions: [N, out_h, out_w]
   sampling_x <- x1$view(c(-1, 1, 1)) + rel_x$view(c(1, output_size[1], output_size[2])) * (x2 - x1)$view(c(-1, 1, 1))
   sampling_y <- y1$view(c(-1, 1, 1)) + rel_y$view(c(1, output_size[1], output_size[2])) * (y2 - y1)$view(c(-1, 1, 1))
 
-  # Concat to get a grid of [N, output_size[1], output_size[2], 2]
+  # Sampling grid: [N, out_h, out_w, 2]
   grid <- torch_stack(list(sampling_x, sampling_y), dim = -1)
 
-  # Bilinear sampling
-  # Feature map is (1, C, H, W), expand to (N, C, H, W) for all ROIs
-  input_expanded <- feature_map$squeeze(1)$unsqueeze(1)$expand(c(num_rois, channels, h_feat, w_feat))
+  # Expand feature map from [1, C, H, W] to [N, C, H, W]
+  input_expanded <- feature_map$expand(c(num_rois, channels, h_feat, w_feat))
 
   pooled_features <- nnf_grid_sample(
     input_expanded,
     grid,
-    mode = "bilinear",
-    padding_mode = "border",
+    mode          = "bilinear",
+    padding_mode  = "border",
     align_corners = FALSE
   )
 
-  # Return [N, C, output_size[1], output_size[2]]
+  # Returns [N, C, out_h, out_w]
   pooled_features
 }
 
@@ -272,9 +269,9 @@ maskrcnn_model <- torch::nn_module(
     },
 
     forward = function(images) {
-      features <- self$backbone(images)
-      rpn_out <- self$rpn(features)
-
+      features   <- self$backbone(images)
+      rpn_out    <- self$rpn(features)
+      device     <- images$device           # inherit device for MPS / CUDA / CPU
 
       batch_size <- images$shape[1]
       image_size <- images$shape[3:4]
@@ -282,18 +279,19 @@ maskrcnn_model <- torch::nn_module(
 
       for (b in seq_len(batch_size)) {
 
-        props <- generate_proposals(features, rpn_out, image_size, c(4, 8, 16, 32),
-                                    batch_idx = b, score_thresh = self$score_thresh,
-                                    nms_thresh = self$nms_thresh)
+        props <- generate_proposals(features, rpn_out, image_size,
+                                    anchor_sizes = list(32, 64, 128, 256),
+                                    batch_idx = b)
 
         if (props$proposals$shape[1] == 0) {
           empty <- list(
-            boxes = torch::torch_empty(c(0, 4)),
-            labels = torch::torch_empty(c(0), dtype = torch::torch_long()),
-            scores = torch::torch_empty(c(0)),
-            masks = torch::torch_empty(c(0, 28, 28))
+            boxes  = torch::torch_empty(c(0, 4),  device = device),
+            labels = torch::torch_empty(c(0), dtype = torch::torch_long(), device = device),
+            scores = torch::torch_empty(c(0),      device = device),
+            masks  = torch::torch_empty(c(0, 28, 28), device = device)
           )
-          return(list(features = features, detections = list(empty)))
+          final_results[[b]] <- empty
+          next
         }
 
         # Limit proposals to avoid slow ROI pooling (common practice in detection)
@@ -305,10 +303,14 @@ maskrcnn_model <- torch::nn_module(
         # Box predictions
         detections <- self$roi_heads(features, props$proposals, batch_idx = b)
 
+        # Softmax over all 91 classes [N, 91]
         scores <- torch::nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch::torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
+
+        # Skip background (column 1 = COCO class 0) — take the argmax over foreground classes only
+        fg_scores    <- scores[, 2:self$num_classes]  # [N, 90]
+        max_fg       <- torch::torch_max(fg_scores, dim = 2)
+        final_scores <- max_fg[[1]]
+        final_labels <- max_fg[[2]] + 1L  # shift back to 91-class indexing
 
         box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
         gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
@@ -321,117 +323,81 @@ maskrcnn_model <- torch::nn_module(
 
         if (num_detections > 0) {
           # Apply filters to deltas, scores, labels, and proposals
-          final_deltas <- deltas[keep, ]
-          final_scores <- final_scores[keep]
-          final_labels <- final_labels[keep]
-
-          # We need the proposals that correspond to these kept detections
-          # 'props$proposals' are the reference boxes (anchors)
+          final_deltas   <- deltas[keep, ]
+          final_scores   <- final_scores[keep]
+          final_labels   <- final_labels[keep]
           kept_proposals <- props$proposals[keep, ]
 
-          # 3. Decode Deltas to Absolute Coordinates
-          # Formula: pred_box = proposal + delta
-          # Standard Faster R-CNN decoding:
-
-          # Widths and Heights of proposals
-          widths <- kept_proposals[, 3] - kept_proposals[, 1]
-          heights <- kept_proposals[, 4] - kept_proposals[, 2]
-
-          # Centers of proposals
-          ctr_x <- kept_proposals[, 1] + 0.5 * widths
-          ctr_y <- kept_proposals[, 2] + 0.5 * heights
-
-          # Extract predicted deltas
-          dx <- final_deltas[, 1]
-          dy <- final_deltas[, 2]
-          dw <- final_deltas[, 3]
-          dh <- final_deltas[, 4]
-
-          # Apply deltas
-          pred_ctr_x <- dx * widths + ctr_x
-          pred_ctr_y <- dy * heights + ctr_y
-          pred_w <- torch_exp(dw) * widths
-          pred_h <- torch_exp(dh) * heights
-
-          # Convert back to (x1, y1, x2, y2)
-          final_boxes <- torch_zeros_like(final_deltas)
-          final_boxes[, 1] <- pred_ctr_x - 0.5 * pred_w # x1
-          final_boxes[, 2] <- pred_ctr_y - 0.5 * pred_h # y1
-          final_boxes[, 3] <- pred_ctr_x + 0.5 * pred_w # x2
-          final_boxes[, 4] <- pred_ctr_y + 0.5 * pred_h # y2
-
-          # Clip Boxes to Image Boundary
-          img_h <- images$shape[3]
-          img_w <- images$shape[4]
-
-          final_boxes <- torch_clamp(final_boxes, min = 0.0)
-          final_boxes[, 1] <- torch_minimum(final_boxes[, 1], img_w)
-          final_boxes[, 2] <- torch_minimum(final_boxes[, 2], img_h)
-          final_boxes[, 3] <- torch_minimum(final_boxes[, 3], img_w)
-          final_boxes[, 4] <- torch_minimum(final_boxes[, 4], img_h)
+          # Decode deltas using the same safe helper as Faster R-CNN
+          # (includes exp-clamping to prevent overflow on MPS / CUDA)
+          final_boxes <- decode_boxes(kept_proposals, final_deltas)
+          final_boxes <- clip_boxes_to_image(final_boxes, image_size)
 
           # Apply NMS and Limit Detections
           if (final_boxes$shape[1] > 0L) {
-            nms_keep <- nms(final_boxes, final_scores, self$nms_thresh)
-            final_boxes <- final_boxes[nms_keep, ]
+            nms_keep     <- nms(final_boxes, final_scores, self$nms_thresh)
+            final_boxes  <- final_boxes[nms_keep, ]
             final_labels <- final_labels[nms_keep]
             final_scores <- final_scores[nms_keep]
-            kept_proposals <- kept_proposals[nms_keep, ]
           }
 
-          # drop degenerate boxes before ROI‑Align
-          valid_boxes_mask <- (kept_proposals[,3] > kept_proposals[,1]) &
-            (kept_proposals[,4] > kept_proposals[,2])
+          # Drop degenerate boxes before ROI-Align (zero-area boxes cause NaN)
+          valid_mask <- (final_boxes[, 3] > final_boxes[, 1]) &
+                        (final_boxes[, 4] > final_boxes[, 2])
 
-          if (valid_boxes_mask$sum()$item() == 0L) {
-            # nothing to pool → empty mask tensor
-            final_masks <- torch::torch_empty(c(0, 28, 28))
+          if (valid_mask$sum()$item() == 0L) {
+            final_masks <- torch::torch_empty(c(0, 28, 28), device = device)
           } else {
-            final_boxes <- final_boxes[valid_boxes_mask, ]
-            final_labels <- final_labels[valid_boxes_mask]
-            final_scores <- final_scores[valid_boxes_mask]
-            kept_proposals <- kept_proposals[valid_boxes_mask, ]
+            final_boxes  <- final_boxes[valid_mask, ]
+            final_labels <- final_labels[valid_mask]
+            final_scores <- final_scores[valid_mask]
           }
 
           # Limit detections per image
           n_det <- final_scores$shape[1]
           if (n_det > self$detections_per_img) {
-            top_k <- torch::torch_topk(final_scores, self$detections_per_img)
-            top_idx <- top_k[[2]]
-            final_boxes <- final_boxes[top_idx, ]
+            top_k        <- torch::torch_topk(final_scores, self$detections_per_img)
+            top_idx      <- top_k[[2]]
+            final_boxes  <- final_boxes[top_idx, ]
             final_labels <- final_labels[top_idx]
             final_scores <- final_scores[top_idx]
-            kept_proposals <- kept_proposals[top_idx, ]
           }
 
-          # Predict masks for kept detections
+          # Predict masks: pool features from the DECODED final_boxes
+          # Extract this specific image's feature maps into shape [1, C, H, W]
+          single_image_features <- list(
+            p2 = features[["p2"]][b, , , , drop = FALSE],
+            p3 = features[["p3"]][b, , , , drop = FALSE],
+            p4 = features[["p4"]][b, , , , drop = FALSE],
+            p5 = features[["p5"]][b, , , , drop = FALSE]
+          )
+
           mask_features <- roi_align_masks_fpn(
-            feature_maps = features,
-            proposals    = kept_proposals,
-            output_size  = c(14L, 14L),
+            feature_maps   = single_image_features,
+            proposals      = final_boxes,
+            output_size    = c(14L, 14L),
             sampling_ratio = 2L,
             aligned        = FALSE
           )
-          mask_conv <- self$mask_head(mask_features)
-          mask_logits <- self$mask_predictor(mask_conv)  # Shape: (N, num_classes, 28, 28)
+          mask_conv   <- self$mask_head(mask_features)
+          mask_logits <- self$mask_predictor(mask_conv)  # [N, num_classes, 28, 28]
 
-          # Extract masks for predicted classes
-          n_kept <- final_labels$shape[1]
-          final_masks <- torch::torch_zeros(c(n_kept, 28, 28))
+          # Extract the mask channel for each detection's predicted class
+          n_kept      <- final_labels$shape[1]
+          final_masks <- torch::torch_zeros(c(n_kept, 28, 28), device = device)
 
           for (i in seq_len(n_kept)) {
             class_idx <- as.integer(final_labels[i]$item())
             final_masks[i, , ] <- mask_logits[i, class_idx, , ]
           }
 
-          # Apply sigmoid to get probabilities
           final_masks <- torch::torch_sigmoid(final_masks)
 
         } else {
-          final_boxes <- torch::torch_empty(c(0, 4))
-          final_labels <- torch::torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch::torch_empty(c(0))
-          final_masks <- torch::torch_empty(c(0, 28, 28))
+          final_boxes  <- torch::torch_empty(c(0, 4),  device = device)
+          final_labels <- torch::torch_empty(c(0), dtype = torch::torch_long(), device = device)
+          final_scores <- torch::torch_empty(c(0),      device = device)
+          final_masks  <- torch::torch_empty(c(0, 28, 28), device = device)
         }
         final_results[[b]] <- list(
           boxes = final_boxes,
@@ -479,24 +445,25 @@ maskrcnn_model_v2 <- torch::nn_module(
     },
 
     forward = function(images) {
-      features <- self$backbone(images)
-      rpn_out <- self$rpn(features)
+      features   <- self$backbone(images)
+      rpn_out    <- self$rpn(features)
+      device     <- images$device           # inherit device for MPS / CUDA / CPU
 
       batch_size <- images$shape[1]
       image_size <- images$shape[3:4]
       final_results <- list()
 
       for (b in seq_len(batch_size)) {
-        props <- generate_proposals(features, rpn_out, image_size, c(4, 8, 16, 32),
-                                    batch_idx = b, score_thresh = self$score_thresh,
-                                    nms_thresh = self$nms_thresh)
+        props <- generate_proposals(features, rpn_out, image_size,
+                                    anchor_sizes = list(32, 64, 128, 256),
+                                    batch_idx = b)
 
         if (props$proposals$shape[1] == 0L) {
           empty <- list(
-            boxes = torch::torch_empty(c(0, 4)),
-            labels = torch::torch_empty(c(0), dtype = torch::torch_long()),
-            scores = torch::torch_empty(c(0)),
-            masks = torch::torch_empty(c(0, 28, 28))
+            boxes  = torch::torch_empty(c(0, 4),  device = device),
+            labels = torch::torch_empty(c(0), dtype = torch::torch_long(), device = device),
+            scores = torch::torch_empty(c(0),      device = device),
+            masks  = torch::torch_empty(c(0, 28, 28), device = device)
           )
           final_results[[b]] <- empty
           next
@@ -511,10 +478,12 @@ maskrcnn_model_v2 <- torch::nn_module(
         # Box predictions
         detections <- self$roi_heads(features, props$proposals, batch_idx = b)
 
-        scores <- torch::nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch::torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
+        scores <- torch::nnf_softmax(detections$scores, dim = 2)  # [N, 91]
+
+        fg_scores    <- scores[, 2:self$num_classes]
+        max_fg       <- torch::torch_max(fg_scores, dim = 2)
+        final_scores <- max_fg[[1]]
+        final_labels <- max_fg[[2]] + 1L  # shift back to 91-class indexing
 
         box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
         gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
@@ -527,112 +496,80 @@ maskrcnn_model_v2 <- torch::nn_module(
 
         if (num_detections > 0) {
           # Apply filters to deltas, scores, labels, and proposals
-          final_deltas <- deltas[keep, ]
-          final_scores <- final_scores[keep]
-          final_labels <- final_labels[keep]
+          final_deltas   <- deltas[keep, ]
+          final_scores   <- final_scores[keep]
+          final_labels   <- final_labels[keep]
           kept_proposals <- props$proposals[keep, ]
 
-          # Decode Deltas to Absolute Coordinates $pred_box = proposal + delta$
+          # Decode deltas using the same safe helper as Faster R-CNN
+          # (includes exp-clamping to prevent overflow on MPS / CUDA)
+          final_boxes <- decode_boxes(kept_proposals, final_deltas)
+          final_boxes <- clip_boxes_to_image(final_boxes, image_size)
 
-          # Widths and Heights of proposals
-          widths <- kept_proposals[, 3] - kept_proposals[, 1]
-          heights <- kept_proposals[, 4] - kept_proposals[, 2]
-
-          # Centers of proposals
-          ctr_x <- kept_proposals[, 1] + 0.5 * widths
-          ctr_y <- kept_proposals[, 2] + 0.5 * heights
-
-          # Extract predicted deltas
-          dx <- final_deltas[, 1]
-          dy <- final_deltas[, 2]
-          dw <- final_deltas[, 3]
-          dh <- final_deltas[, 4]
-
-          # Apply deltas
-          pred_ctr_x <- dx * widths + ctr_x
-          pred_ctr_y <- dy * heights + ctr_y
-          pred_w <- torch_exp(dw) * widths
-          pred_h <- torch_exp(dh) * heights
-
-          # Convert back to (x1, y1, x2, y2)
-          final_boxes <- torch_zeros_like(final_deltas)
-          final_boxes[, 1] <- pred_ctr_x - 0.5 * pred_w # x1
-          final_boxes[, 2] <- pred_ctr_y - 0.5 * pred_h # y1
-          final_boxes[, 3] <- pred_ctr_x + 0.5 * pred_w # x2
-          final_boxes[, 4] <- pred_ctr_y + 0.5 * pred_h # y2
-
-          # Clip Boxes to Image Boundary
-          img_h <- images$shape[3]
-          img_w <- images$shape[4]
-
-          final_boxes <- torch_clamp(final_boxes, min = 0.0)
-          final_boxes[, 1] <- torch_minimum(final_boxes[, 1], img_w)
-          final_boxes[, 2] <- torch_minimum(final_boxes[, 2], img_h)
-          final_boxes[, 3] <- torch_minimum(final_boxes[, 3], img_w)
-          final_boxes[, 4] <- torch_minimum(final_boxes[, 4], img_h)
-
-          # Apply NMS and Limit Detections
+          # Apply NMS
           if (final_boxes$shape[1] > 1L) {
-            nms_keep <- nms(final_boxes, final_scores, self$nms_thresh)
-            final_boxes <- final_boxes[nms_keep, ]
+            nms_keep     <- nms(final_boxes, final_scores, self$nms_thresh)
+            final_boxes  <- final_boxes[nms_keep, ]
             final_labels <- final_labels[nms_keep]
             final_scores <- final_scores[nms_keep]
-            kept_proposals <- kept_proposals[nms_keep, ]
           }
 
+          # Drop degenerate boxes before ROI-Align (zero-area boxes cause NaN)
+          valid_mask <- (final_boxes[, 3] > final_boxes[, 1]) &
+                        (final_boxes[, 4] > final_boxes[, 2])
 
-          # drop degenerate boxes before ROI‑Align
-          valid_boxes_mask <- (kept_proposals[,3] > kept_proposals[,1]) &
-            (kept_proposals[,4] > kept_proposals[,2])
-
-          if (valid_boxes_mask$sum()$item() == 0L) {
-            # nothing to pool → empty mask tensor
-            final_masks <- torch::torch_empty(c(0, 28, 28))
+          if (valid_mask$sum()$item() == 0L) {
+            final_masks <- torch::torch_empty(c(0, 28, 28), device = device)
           } else {
-            final_boxes <- final_boxes[valid_boxes_mask, ]
-            final_labels <- final_labels[valid_boxes_mask]
-            final_scores <- final_scores[valid_boxes_mask]
-            kept_proposals <- kept_proposals[valid_boxes_mask, ]
+            final_boxes  <- final_boxes[valid_mask, ]
+            final_labels <- final_labels[valid_mask]
+            final_scores <- final_scores[valid_mask]
           }
 
           # Limit detections per image
           n_det <- final_scores$shape[1]
           if (n_det > self$detections_per_img) {
-            top_k <- torch::torch_topk(final_scores, self$detections_per_img)
-            top_idx <- top_k[[2]]
-            final_boxes <- final_boxes[top_idx, ]
+            top_k        <- torch::torch_topk(final_scores, self$detections_per_img)
+            top_idx      <- top_k[[2]]
+            final_boxes  <- final_boxes[top_idx, ]
             final_labels <- final_labels[top_idx]
             final_scores <- final_scores[top_idx]
-            kept_proposals <- kept_proposals[top_idx, ]
           }
 
-          # Predict masks for kept detections
+          # Predict masks: pool features from the DECODED final_boxes
+          # Extract this specific image's feature maps into shape [1, C, H, W]
+          single_image_features <- list(
+            p2 = features[["p2"]][b, , , , drop = FALSE],
+            p3 = features[["p3"]][b, , , , drop = FALSE],
+            p4 = features[["p4"]][b, , , , drop = FALSE],
+            p5 = features[["p5"]][b, , , , drop = FALSE]
+          )
+
           mask_features <- roi_align_masks_fpn(
-            feature_maps = features,
-            proposals    = kept_proposals,      # still in image space
-            output_size  = c(14L, 14L),
+            feature_maps   = single_image_features,
+            proposals      = final_boxes,
+            output_size    = c(14L, 14L),
             sampling_ratio = 2L,
             aligned        = FALSE
           )
-          mask_logits   <- self$mask_head(mask_features)       # (N, num_classes, 28, 28)
+          mask_logits <- self$mask_head(mask_features)   # [N, num_classes, 28, 28]
 
-          # Extract masks for predicted classes
-          n_kept <- final_labels$shape[1]
-          final_masks <- torch::torch_zeros(c(n_kept, 28, 28))
+          # Extract the mask channel for each detection's predicted class
+          n_kept      <- final_labels$shape[1]
+          final_masks <- torch::torch_zeros(c(n_kept, 28, 28), device = device)
 
           for (i in seq_len(n_kept)) {
             class_idx <- as.integer(final_labels[i]$item())
             final_masks[i, , ] <- mask_logits[i, class_idx, , ]
           }
 
-          # Apply sigmoid to get probabilities
           final_masks <- torch::torch_sigmoid(final_masks)
 
         } else {
-          final_boxes <- torch::torch_empty(c(0, 4))
-          final_labels <- torch::torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch::torch_empty(c(0))
-          final_masks <- torch::torch_empty(c(0, 28, 28))
+          final_boxes  <- torch::torch_empty(c(0, 4),  device = device)
+          final_labels <- torch::torch_empty(c(0), dtype = torch::torch_long(), device = device)
+          final_scores <- torch::torch_empty(c(0),      device = device)
+          final_masks  <- torch::torch_empty(c(0, 28, 28), device = device)
         }
         final_results[[b]] <- list(
           boxes = final_boxes,
@@ -803,8 +740,7 @@ model_maskrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE,
     }
 
     state_dict <- torch::load_state_dict(state_dict_path)
-
-    # Load with flexible matching (similar to fasterrcnn_v2)
+    state_dict <- .rename_maskrcnn_state_dict_v2(state_dict)
     model_state <- model$state_dict()
     state_dict <- state_dict[names(state_dict) %in% names(model_state)]
     for (n in names(state_dict)) {
@@ -819,7 +755,7 @@ model_maskrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE,
       }
     }
 
-    model$load_state_dict(state_dict, strict = TRUE)
+    model$load_state_dict(state_dict)
   }
 
   model
@@ -847,7 +783,13 @@ model_maskrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE,
     # change roi_head prefix into mask_head.mask_
     sub(pattern = "roi_heads\\.mask_", replacement = "mask_head\\.mask_", x = .) %>%
     sub(pattern = "roi_heads\\.box_head\\.5\\.", replacement = "roi_heads\\.box_head\\.4\\.", x = .) %>%
-    sub(pattern = "(mask_head\\.mask_predictor\\.conv5_mask)", replacement = "\\1\\.0", x = .)
+    sub(pattern = "(mask_head\\.mask_predictor\\.conv5_mask)", replacement = "\\1\\.0", x = .) %>%
+    # Fix FPN Sequential nesting: Conv layers (PyTorch 0.0 -> R 0)
+    sub(pattern = "(inner_blocks\\.[0-3]\\.)0\\.0\\.", replacement = "\\10\\.", x = .) %>%
+    sub(pattern = "(layer_blocks\\.[0-3]\\.)0\\.0\\.", replacement = "\\10\\.", x = .) %>%
+    # BN layers (PyTorch 0.1 -> R 1)
+    sub(pattern = "(inner_blocks\\.[0-3]\\.)0\\.1\\.", replacement = "\\11\\.", x = .) %>%
+    sub(pattern = "(layer_blocks\\.[0-3]\\.)0\\.1\\.", replacement = "\\11\\.", x = .)
 
   # Recreate a list with renamed keys
   setNames(state_dict[names(state_dict)], new_names)


### PR DESCRIPTION
This PR fixes the issues in #316 where the `fasterrcnn_*` and `maskrcnn_*` models were only predicting the background class and crashing on non-CPU devices (like MPS/CUDA).  

**What changed:**
* Fixed anchor generation to match the sizes correctly expected by the pretrained weights (instead of creating tiny square anchors).
* Added background class suppression so the model doesn't always default to picking `_background_`.
* Switched to calculating multi-scale ROI pooling properly instead of only ever sampling from the first feature map level.
* Fixed the `decode_boxes` output shape bug.
* Passed the `device` argument properly to all `torch_empty` and `torch_zeros` calls so the tensor devices match the input images, preventing crashes on MPS.
* Replaced unsafe manual math during mask extraction with the clamp-protected `decode_boxes()` helper to prevent `exp()` overflow.