### PR TITLE
Fix models `faster_rcnn_` and `mask_rcnn_` architecture

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Breaking changes
 
 * Split `coco_detection_dataset()` into `coco_detection_dataset()` (detection only) and new `coco_segmentation_dataset()` (instance segmentation) reducing memory usage by ~50% (@Chandraveersingh1717, #280).
+* `coco_classes()` is now aligned with the 90 sparse pytorch COCO classses, in order to match pretrained model predictions. (@318).
 * Renamed `$categories` to `$classes` for consistency (character vector of class names; old attribute is deprecated with a warning) (#300).
 
 ## New features
@@ -24,8 +25,9 @@
 * Added `vggface2_dataset()` for loading the VGGFace2 dataset (@DerrickUnleashed, #238).
 * Added `moth` dataset to `rf100_biology_collection()` and `currency` and `wine_label` to `rf100_document_collection()` (#274).
 
-## Minor bug fixes and improvements
+## Bug fixes and improvements
 
+* `model_maskrcnn_*()` and `model_fasterrcnn_*()` now match the pytorch implementation (#318).
 * `transform_` now correctly manage batched 4D torch tensors and 4D arrays (#313).
 * `mnist_datataset()` and derivatives now correctly return item x() values with a 1-channel dimension (@Chandraveersingh1717, #307).
 * `transform_affine()`, `transform_rotate()` and random derivatives now use `interpolation` and `fill` parameter in favor of `resample`and `fillcolor` (@Chandraveersingh1717, #299).

--- a/R/dataset-coco.R
+++ b/R/dataset-coco.R
@@ -428,20 +428,111 @@ coco_caption_dataset <- torch::dataset(
 
 #' MS COCO Class Labels
 #'
-#' Utilities for resolving COCO 81 class identifiers to their corresponding
-#' human readable labels. The labels are retrieved from ultralytics source
+#' Utilities for resolving COCO 90 class identifiers to their corresponding
+#' human readable labels. The labels are retrieved from pytorch/vision source to be compliant
+#' with torchvision pretrained models.
 #'
 #' @param class_id Integer vector of 1-based class identifiers.
 #' @return A character vector with the COCO class names
 #' @family class_resolution
 #' @importFrom utils read.delim
 #' @export
-coco_classes <- function(class_id = 1:81) {
-  if (any(class_id > 81)) {
-    cli_warn("MS COCO {.var class_id} cannot be > 81")
+coco_classes <- function(class_id = 1:90) {
+  if (any(class_id > 90)) {
+    cli_warn("MS COCO {.var class_id} cannot be > 90")
   }
-  url <- download_and_cache("https://github.com/ultralytics/ultralytics/raw/refs/heads/main/ultralytics/cfg/datasets/coco.yaml")
-  labels <- c("_background_", read.delim(url, skip = 18, sep = ":", nrows = 80, strip.white = TRUE, header = FALSE)[,2])
+
+  labels <- c("person",
+    "bicycle",
+    "car",
+    "motorcycle",
+    "airplane",
+    "bus",
+    "train",
+    "truck",
+    "boat",
+    "traffic light",
+    "fire hydrant",
+    "N/A",
+    "stop sign",
+    "parking meter",
+    "bench",
+    "bird",
+    "cat",
+    "dog",
+    "horse",
+    "sheep",
+    "cow",
+    "elephant",
+    "bear",
+    "zebra",
+    "giraffe",
+    "N/A",
+    "backpack",
+    "umbrella",
+    "N/A",
+    "N/A",
+    "handbag",
+    "tie",
+    "suitcase",
+    "frisbee",
+    "skis",
+    "snowboard",
+    "sports ball",
+    "kite",
+    "baseball bat",
+    "baseball glove",
+    "skateboard",
+    "surfboard",
+    "tennis racket",
+    "bottle",
+    "N/A",
+    "wine glass",
+    "cup",
+    "fork",
+    "knife",
+    "spoon",
+    "bowl",
+    "banana",
+    "apple",
+    "sandwich",
+    "orange",
+    "broccoli",
+    "carrot",
+    "hot dog",
+    "pizza",
+    "donut",
+    "cake",
+    "chair",
+    "couch",
+    "potted plant",
+    "bed",
+    "N/A",
+    "dining table",
+    "N/A",
+    "N/A",
+    "toilet",
+    "N/A",
+    "tv",
+    "laptop",
+    "mouse",
+    "remote",
+    "keyboard",
+    "cell phone",
+    "microwave",
+    "oven",
+    "toaster",
+    "sink",
+    "refrigerator",
+    "N/A",
+    "book",
+    "clock",
+    "vase",
+    "scissors",
+    "teddy bear",
+    "hair drier",
+    "toothbrush"
+  )
   labels[nzchar(labels)][class_id]
 }
 

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -444,7 +444,7 @@ fasterrcnn_model <- torch::nn_module(
 
       for (b in seq_len(batch_size)) {
         props <- generate_proposals(features, rpn_out, image_size, c(4, 8, 16, 32),
-                                    batch_idx = b, score_thresh = self$score_thresh,
+                                    batch_idx = b, score_thresh = 0,
                                     nms_thresh = self$nms_thresh)
 
         if (props$proposals$shape[1] == 0) {
@@ -470,8 +470,8 @@ fasterrcnn_model <- torch::nn_module(
         final_boxes <- decode_boxes(props$proposals, final_boxes)
         final_boxes <- clip_boxes_to_image(final_boxes, image_size)
 
-        # Filter by score threshold
-        keep <- final_scores > self$score_thresh
+        # Filter by score threshold AND remove background predictions (class 1)
+        keep <- (final_scores > self$score_thresh) & (final_labels != 1)
         num_detections <- torch::torch_sum(keep)$item()
 
         if (num_detections > 0) {
@@ -635,7 +635,7 @@ fasterrcnn_model_v2 <- torch::nn_module(
 
       for (b in seq_len(batch_size)) {
         props <- generate_proposals(features, rpn_out, image_size, c(4, 8, 16, 32),
-                                    batch_idx = b, score_thresh = self$score_thresh,
+                                    batch_idx = b, score_thresh = 0,
                                     nms_thresh = self$nms_thresh)
 
         if (props$proposals$shape[1] == 0) {
@@ -661,8 +661,8 @@ fasterrcnn_model_v2 <- torch::nn_module(
         final_boxes <- decode_boxes(props$proposals, final_boxes)
         final_boxes <- clip_boxes_to_image(final_boxes, image_size)
 
-        # Filter by score threshold
-        keep <- final_scores > self$score_thresh
+        # Filter by score threshold AND remove background predictions (class 1)
+        keep <- (final_scores > self$score_thresh) & (final_labels != 1)
         num_detections <- torch::torch_sum(keep)$item()
 
         if (num_detections > 0) {
@@ -796,7 +796,7 @@ fasterrcnn_mobilenet_model <- torch::nn_module(
 
       for (b in seq_len(batch_size)) {
         props <- generate_proposals(features, rpn_out, image_size, c(8, 16),
-                                    batch_idx = b, score_thresh = self$score_thresh,
+                                    batch_idx = b, score_thresh = 0,
                                     nms_thresh = self$nms_thresh)
 
         if (props$proposals$shape[1] == 0) {

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -116,22 +116,21 @@ generate_level_anchors <- function(h, w, stride, base_sizes = c(32, 64, 128, 256
   anchors$reshape(orig_shape)
 }
 
-decode_boxes <- function(anchors, deltas, weights = c(10.0, 10.0, 5.0, 5.0)) {
+decode_boxes <- function(anchors, deltas, weights = c(10, 10, 5, 5)) {
   widths <- anchors[, 3] - anchors[, 1]
   heights <- anchors[, 4] - anchors[, 2]
   ctr_x <- anchors[, 1] + widths / 2
   ctr_y <- anchors[, 2] + heights / 2
 
-  # Apply bbox regression weights (default: 10.0, 10.0, 5.0, 5.0)
+  # Apply bbox regression weights (default: 10, 10, 5, 5)
   dx <- deltas[, 1] / weights[1]
   dy <- deltas[, 2] / weights[2]
   dw <- deltas[, 3] / weights[3]
   dh <- deltas[, 4] / weights[4]
 
-  # Clamp dw and dh to prevent numerical instability in exp()
-  bbox_xform_clip <- log(1000.0 / 16.0)  # ~4.135
-  dw <- torch::torch_clamp(dw, max = bbox_xform_clip)
-  dh <- torch::torch_clamp(dh, max = bbox_xform_clip)
+  # Clamp dw and dh to prevent numerical instability in exp() to log(1000 / 16)  # ~4.135
+  dw <- torch::torch_clamp(dw, max = 4.135)
+  dh <- torch::torch_clamp(dh, max = 4.135)
 
   pred_ctr_x <- ctr_x + dx * widths
   pred_ctr_y <- ctr_y + dy * heights
@@ -273,11 +272,11 @@ generate_proposals <- function(features, rpn_out, image_size, strides, batch_idx
     if (a == 15) {
       base_sizes <- c(32, 64, 128, 256, 512)
     } else if (a == 3) {
-      base_sizes <- c(4.0 * strides[[i]])
+      base_sizes <- c(4 * strides[[i]])
     } else {
       value_error("Unexpected number of anchors: {a}. Expected 3 or 15.")
     }
-    anchors <- generate_level_anchors(h, w, strides[[i]], base_sizes = base_sizes, aspect_ratios = c(0.5, 1.0, 2.0), device = device)
+    anchors <- generate_level_anchors(h, w, strides[[i]], base_sizes = base_sizes, aspect_ratios = c(0.5, 1, 2), device = device)
     anchors <- anchors$reshape(c(-1, 4))  # [H*W*A, 4]
 
     objectness <- objectness$sigmoid()$flatten() ## [H*W*A]

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -24,13 +24,12 @@ rpn_head <- torch::nn_module(
 rpn_head_v2 <- torch::nn_module(
     "rpn_head_v2",
     initialize = function(in_channels, num_anchors = 3) {
-      # The pretrained checkpoint stacks two Conv2d → BatchNorm2d → ReLU
-      # blocks with bias disabled on the convolutions. Mirror that layout so
-      # the parameter names and shapes line up with the weight file.
+      # PyTorch V2 uses Conv2dNormActivation with norm_layer=None, which creates
+      # Conv2d with bias=True, NO batch norm, and ReLU activation.
+      # This matches torchvision.ops.misc.Conv2dNormActivation behavior when norm_layer=None.
       block <- function() {
         nn_sequential(
-          nn_conv2d(in_channels, in_channels, kernel_size = 3, padding = 1, bias = FALSE),
-          nn_batch_norm2d(in_channels),
+          nn_conv2d(in_channels, in_channels, kernel_size = 3, padding = 1, bias = TRUE),
           nn_relu()
         )
       }
@@ -361,7 +360,7 @@ roi_align <- function(feature_map, proposals, batch_idx, output_size = c(7L, 7L)
 }
 
 roi_heads_module <-  torch::nn_module(
-    "region-of-interest head v2",
+    "region-of-interest head",
     initialize = function(num_classes = 90) {
       # num_classes excludes background, but predictor needs background + all classes
       num_classes_with_bg <- num_classes + 1L
@@ -400,35 +399,45 @@ roi_heads_module <-  torch::nn_module(
     }
   )
 
-
-roi_heads_module_v2 <- torch::nn_module(
+roi_heads_module_v2 <-  torch::nn_module(
     "region-of-interest head v2",
-    initialize = function(num_classes = 90) {
+    initialize = function(num_classes = 90, in_channels = 256) {
       # num_classes excludes background, but predictor needs background + all classes
       num_classes_with_bg <- num_classes + 1L
 
-      # The pretrained weights expect four (Linear -> BN -> ReLU) blocks
-      # followed by a final linear layer at index "4".
-      block <- function() {
-        nn_sequential(
-          nn_linear(1024, 1024, bias = FALSE),
-          nn_batch_norm1d(1024),
-          nn_relu()
-        )
-      }
+      # V2 uses FastRCNNConvFCHead: 4 conv layers + 1 FC layer
+      # PyTorch: FastRCNNConvFCHead((256, 7, 7), [256, 256, 256, 256], [1024], norm_layer=BatchNorm2d)
+      self$box_head <- torch::nn_module(
+        initialize = function() {
+          # 4 Conv2d + BatchNorm + ReLU blocks
+          conv_block <- function(in_ch, out_ch) {
+            nn_sequential(
+              nn_conv2d(in_ch, out_ch, kernel_size = 3, padding = 1, bias = TRUE),
+              nn_batch_norm2d(out_ch),
+              nn_relu()
+            )
+          }
+          self[[0]] <- conv_block(in_channels, 256)
+          self[[1]] <- conv_block(256, 256)
+          self[[2]] <- conv_block(256, 256)
+          self[[3]] <- conv_block(256, 256)
+          # Flatten happens in forward()
+          # FC layer: 256 * 7 * 7 = 12544 -> 1024
+          self[[4]] <- nn_linear(256 * 7 * 7, 1024, bias = TRUE)
+        },
+        forward = function(x) {
+          # x is [N, 256, 7, 7]
+          x <- self[[0]](x)
+          x <- self[[1]](x)
+          x <- self[[2]](x)
+          x <- self[[3]](x)
+          x <- x$flatten(start_dim = 1)  # [N, 256*7*7]
+          x <- self[[4]](x)              # [N, 1024]
+          x <- nnf_relu(x)
+          x
+        }
+      )()
 
-      layers <- list(
-        nn_sequential(
-          nn_linear(256 * 7 * 7, 1024, bias = FALSE),
-          nn_batch_norm1d(1024),
-          nn_relu()
-        ),
-        block(),
-        block(),
-        block(),
-        nn_linear(1024, 1024, bias = TRUE)
-      )
-      self$box_head <- do.call(nn_sequential, layers)
       self$box_predictor <- torch::nn_module(
         initialize = function() {
           self$cls_score <- torch::nn_linear(1024, num_classes_with_bg, bias = TRUE)
@@ -443,8 +452,9 @@ roi_heads_module_v2 <- torch::nn_module(
       )()
     },
     forward = function(features, proposals, batch_idx) {
-      pooled <- roi_align(features[[1]], proposals, batch_idx)
-      x <- self$box_head(pooled$flatten(start_dim = 2))
+      feature_maps <- features[c("p2", "p3", "p4", "p5")]
+      pooled <- roi_align(feature_maps[[1]], proposals, batch_idx)
+      x <- self$box_head(pooled)
       self$box_predictor(x)
     }
   )
@@ -969,21 +979,6 @@ mobilenet_v3_320_fpn_backbone <- function(pretrained = TRUE) {
 #'   transform_normalize(norm_mean, norm_std)
 #' batch_normalized <- input$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
 #'
-#' # ResNet-50 FPN
-#' model <- model_fasterrcnn_resnet50_fpn(pretrained = TRUE, score_thresh = 0.5,
-#'                                         nms_thresh = 0.8, detections_per_img = 3)
-#' model$eval()
-#' torch::with_no_grad({pred <- model(batch_normalized)$detections[[1]]})
-#'
-#' num_boxes <- as.integer(pred$boxes$size()[1])
-#' keep <- seq_len(min(5, num_boxes))
-#' boxes <- pred$boxes[keep, ]$view(c(-1, 4))
-#' labels <- coco_classes(as.integer(pred$labels[keep]))
-#' if (num_boxes > 0) {
-#'   boxed <- draw_bounding_boxes(image, boxes, labels = labels)
-#'   tensor_image_browse(boxed)
-#' }
-#'
 #' # ResNet-50 FPN V2
 #' model <- model_fasterrcnn_resnet50_fpn_v2(pretrained = TRUE)
 #' model$eval()
@@ -997,26 +992,8 @@ mobilenet_v3_320_fpn_backbone <- function(pretrained = TRUE) {
 #'   tensor_image_browse(boxed)
 #' }
 #'
-#' # MobileNet V3 Large FPN
-#' batch <- image$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
-#'
-#' model <- model_fasterrcnn_mobilenet_v3_large_fpn(
-#'   pretrained = TRUE, score_thresh = 0.02, nms_thresh = 0.9, detections_per_img = 5
-#' )
-#' model$eval()
-#' torch::with_no_grad({
-#'   pred <- model(batch)$detections[[1]]
-#' })
-#' num_boxes <- as.integer(pred$boxes$size()[1])
-#' keep <- seq_len(min(5, num_boxes))
-#' boxes <- pred$boxes[keep, ]$view(c(-1, 4))
-#' labels <- coco_classes(as.integer(pred$labels[keep]))
-#' if (num_boxes > 0) {
-#'   boxed <- draw_bounding_boxes(image, boxes, labels = labels)
-#'   tensor_image_browse(boxed)
-#' }
-#'
 #' # MobileNet V3 Large 320 FPN
+#' batch <- image$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
 #' model <- model_fasterrcnn_mobilenet_v3_large_320_fpn(
 #'   pretrained = TRUE, score_thresh = 0.02, nms_thresh = 0.8, detections_per_img = 5
 #' )

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -185,7 +185,7 @@ postprocess_detections <- function(class_logits, box_regression, proposals,
 
   # Remove background class (class 1 in 1-based indexing)
   # Keep classes 2 through num_classes
-  pred_boxes <- pred_boxes[, 2:num_classes, ]      # [N, num_classes-1, 4]
+  pred_boxes <- decoded_boxes[, 2:num_classes, ]   # [N, num_classes-1, 4]
   pred_scores <- pred_scores[, 2:num_classes]       # [N, num_classes-1]
 
   num_classes_no_bg <- num_classes - 1L

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -152,10 +152,10 @@ decode_boxes <- function(anchors, deltas, weights = c(10.0, 10.0, 5.0, 5.0)) {
 #' Keeps all class predictions before filtering, rather than taking max across
 #' classes first, allowing proper per-class NMS.
 #'
-#' @param class_logits Tensor of shape [N, num_classes_with_bg] - raw classification scores including background
-#' @param box_regression Tensor of shape [N, num_classes_with_bg * 4] - box deltas for each class
-#' @param proposals Tensor of shape [N, 4] - proposal boxes in (x1, y1, x2, y2) format
-#' @param image_size Integer vector of length 2: [height, width]
+#' @param class_logits Tensor of shape \[N, num_classes_with_bg\] - raw classification scores including background
+#' @param box_regression Tensor of shape \[N, num_classes_with_bg * 4\] - box deltas for each class
+#' @param proposals Tensor of shape \[N, 4\] - proposal boxes in (x1, y1, x2, y2) format
+#' @param image_size Integer vector of length 2: \[height, width\]
 #' @param num_classes Integer - number of classes excluding background (e.g., 90 for COCO)
 #' @param score_thresh Numeric - minimum score threshold for detections
 #' @param nms_thresh Numeric - NMS IoU threshold
@@ -164,7 +164,7 @@ decode_boxes <- function(anchors, deltas, weights = c(10.0, 10.0, 5.0, 5.0)) {
 #' @details
 #' Box regression uses standard Faster R-CNN decoding with weights (10, 10, 5, 5).
 #' Background class (index 1 in class_logits) is removed, returning labels
-#' in range [1, num_classes] which correspond to COCO classes [1=person, 2=bicycle, ..., 90=toothbrush].
+#' in range \[1, num_classes\] which correspond to COCO classes \[1=person, 2=bicycle, ..., 90=toothbrush\].
 #'
 #' @return List with boxes, labels, scores tensors
 #' @noRd

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -76,30 +76,45 @@ rpn_head_mobilenet <- torch::nn_module(
 
 
 #' @importFrom torch torch_meshgrid torch_stack torch_tensor torch_stack torch_zeros_like torch_max torch_float32
-generate_level_anchors <- function(h, w, stride, scales) {
+generate_level_anchors <- function(h, w, stride, base_sizes = c(32, 64, 128, 256, 512), aspect_ratios = c(0.5, 1.0, 2.0), device = "cpu") {
   # Grid centers
-  shift_x <- torch_arange(0.5, w - 0.5, 1.0) * stride
-  shift_y <- torch_arange(0.5, h - 0.5, 1.0) * stride
+  shift_x <- torch_arange(0.5, w - 0.5, 1.0, device = device) * stride
+  shift_y <- torch_arange(0.5, h - 0.5, 1.0, device = device) * stride
   shifts <- torch_meshgrid(list(shift_x, shift_y), indexing = "xy")
-  shift_grid <- torch_stack(list(shifts[[1]], shifts[[2]], shifts[[1]], shifts[[2]]), dim = 3)$unsqueeze(3)  # [H, W, 1, 4]
+  shift_grid <- torch_stack(list(shifts[[1]], shifts[[2]], torch_zeros_like(shifts[[1]]), torch_zeros_like(shifts[[2]])), dim = 3)$unsqueeze(3)  # [H, W, 1, 4]
 
-  # Anchor sizes (width/height)
-  # Example: square anchors per scale
-  anchor_sizes <- torch_tensor(scales) * stride  # [A]
-  anchor_widths <- anchor_sizes
-  anchor_heights <- anchor_sizes
+  # Create anchors for each combination of base_size and aspect_ratio
+  anchor_list <- list()
 
-  # Create base anchors [A, 4] (xc, yc, w, h)
+  for (base_size in base_sizes) {
+    for (ratio in aspect_ratios) {
+      w_anchor <- base_size * sqrt(ratio)
+      h_anchor <- base_size / sqrt(ratio)
+      anchor_list[[length(anchor_list) + 1]] <- c(w_anchor, h_anchor)
+    }
+  }
+
+  # Stack anchors [A, 2]
+  anchors_wh <- do.call(rbind, anchor_list)
+  anchor_widths <- torch_tensor(anchors_wh[, 1], device = device)
+  anchor_heights <- torch_tensor(anchors_wh[, 2], device = device)
+
+  # Create base anchors [4, A] then transpose to [A, 4] (xc, yc, w, h)
   anchors <- torch_stack(list(
-    torch_zeros_like(anchor_sizes),
-    torch_zeros_like(anchor_sizes),
+    torch_zeros_like(anchor_widths),
+    torch_zeros_like(anchor_heights),
     anchor_widths,
     anchor_heights
-  ), dim = 1)  # [A, 4]
+  ), dim = 1)$permute(c(2, 1))
 
   # Expand to [H, W, A, 4]
   anchors <- anchors$reshape(c(1, 1, -1, 4)) + shift_grid  # Broadcasting
-  anchors
+
+  # Convert from (xc, yc, w, h) to (x1, y1, x2, y2)
+  orig_shape <- anchors$shape
+  anchors <- anchors$reshape(c(-1, 4))
+  anchors <- box_cxcywh_to_xyxy(anchors)
+  anchors$reshape(orig_shape)
 }
 
 decode_boxes <- function(anchors, deltas) {
@@ -139,7 +154,14 @@ generate_proposals <- function(features, rpn_out, image_size, strides, batch_idx
 
     c(a, h, w) %<-% objectness$shape
 
-    anchors <- generate_level_anchors(h, w, strides[[i]], scales = seq_len(a))
+    if (a == 15) {
+      base_sizes <- c(32, 64, 128, 256, 512)
+    } else if (a == 3) {
+      base_sizes <- c(4.0 * strides[[i]])
+    } else {
+      value_error("Unexpected number of anchors: {a}. Expected 3 or 15.")
+    }
+    anchors <- generate_level_anchors(h, w, strides[[i]], base_sizes = base_sizes, aspect_ratios = c(0.5, 1.0, 2.0), device = device)
     anchors <- anchors$reshape(c(-1, 4))  # [H*W*A, 4]
 
     objectness <- objectness$sigmoid()$flatten() ## [H*W*A]
@@ -199,6 +221,10 @@ roi_align <- function(feature_map, proposals, batch_idx, output_size = c(7L, 7L)
   sampling_x <- x1$view(c(-1, 1, 1)) + rel_x$view(c(1, output_size[1], output_size[2])) * (x2 - x1)$view(c(-1, 1, 1))
   sampling_y <- y1$view(c(-1, 1, 1)) + rel_y$view(c(1, output_size[1], output_size[2])) * (y2 - y1)$view(c(-1, 1, 1))
 
+  # Clamp grid to [-1, 1] to avoid needing padding (especially for MPS compatibility)
+  sampling_x <- sampling_x$clamp(-1, 1)
+  sampling_y <- sampling_y$clamp(-1, 1)
+
   # Concat to get a grid of [N, 7, 7, 2]
   grid <- torch_stack(list(sampling_x, sampling_y), dim = -1)
 
@@ -209,7 +235,7 @@ roi_align <- function(feature_map, proposals, batch_idx, output_size = c(7L, 7L)
     input_selected,
     grid,
     mode = "bilinear",
-    padding_mode = "border",
+    padding_mode = "zeros",
     align_corners = FALSE
   )
 

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -409,7 +409,6 @@ roi_heads_module_v2 <-  torch::nn_module(
       # PyTorch: FastRCNNConvFCHead((256, 7, 7), [256, 256, 256, 256], [1024], norm_layer=BatchNorm2d)
       self$box_head <- torch::nn_module(
         initialize = function() {
-          # 4 Conv2d + BatchNorm + ReLU blocks
           conv_block <- function(in_ch, out_ch) {
             nn_sequential(
               nn_conv2d(in_ch, out_ch, kernel_size = 3, padding = 1, bias = TRUE),
@@ -417,22 +416,22 @@ roi_heads_module_v2 <-  torch::nn_module(
               nn_relu()
             )
           }
-          self[[0]] <- conv_block(in_channels, 256)
-          self[[1]] <- conv_block(256, 256)
-          self[[2]] <- conv_block(256, 256)
-          self[[3]] <- conv_block(256, 256)
-          # Flatten happens in forward()
-          # FC layer: 256 * 7 * 7 = 12544 -> 1024
-          self[[4]] <- nn_linear(256 * 7 * 7, 1024, bias = TRUE)
+          # State dict expects numeric indices: 0, 1, 2, 3, 4
+          # Use character names that will be accessed as self[["0"]], etc.
+          self[["0"]] <- conv_block(in_channels, 256)
+          self[["1"]] <- conv_block(256, 256)
+          self[["2"]] <- conv_block(256, 256)
+          self[["3"]] <- conv_block(256, 256)
+          self[["4"]] <- nn_linear(256 * 7 * 7, 1024, bias = TRUE)
         },
         forward = function(x) {
           # x is [N, 256, 7, 7]
-          x <- self[[0]](x)
-          x <- self[[1]](x)
-          x <- self[[2]](x)
-          x <- self[[3]](x)
-          x <- x$flatten(start_dim = 1)  # [N, 256*7*7]
-          x <- self[[4]](x)              # [N, 1024]
+          x <- self[["0"]](x)
+          x <- self[["1"]](x)
+          x <- self[["2"]](x)
+          x <- self[["3"]](x)
+          x <- x$flatten(start_dim = 2)  # [N, 256*7*7]
+          x <- self[["4"]](x)            # [N, 1024]
           x <- nnf_relu(x)
           x
         }

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -141,6 +141,109 @@ decode_boxes <- function(anchors, deltas) {
   torch::torch_stack(list(x1, y1, x2, y2), dim = 2)
 }
 
+#' Postprocess Detections
+#'
+#' Processes class logits and box regression to produce final detections.
+#' Keeps all class predictions before filtering, rather than taking max across
+#' classes first, allowing proper per-class NMS.
+#'
+#' @param class_logits Tensor of shape [N, num_classes] - raw classification scores
+#' @param box_regression Tensor of shape [N, num_classes * 4] - box deltas for each class
+#' @param proposals Tensor of shape [N, 4] - proposal boxes in (x1, y1, x2, y2) format
+#' @param image_size Integer vector of length 2: [height, width]
+#' @param num_classes Integer - total number of classes including background
+#' @param score_thresh Numeric - minimum score threshold for detections
+#' @param nms_thresh Numeric - NMS IoU threshold
+#' @param detections_per_img Integer - maximum detections to return
+#'
+#' @return List with boxes, labels, scores tensors
+#' @noRd
+postprocess_detections <- function(class_logits, box_regression, proposals,
+                                   image_size, num_classes, score_thresh,
+                                   nms_thresh, detections_per_img) {
+  device <- class_logits$device
+  num_proposals <- proposals$shape[1]
+
+  # Decode boxes for all classes: [N, num_classes, 4]
+  pred_boxes <- box_regression$view(c(num_proposals, num_classes, 4))
+
+  # Decode boxes using proposals as anchors (expand proposals for all classes)
+  proposals_expanded <- proposals$unsqueeze(2)$expand(c(num_proposals, num_classes, 4))
+
+  # Decode for each class
+  decoded_boxes <- torch_zeros_like(pred_boxes)
+  for (cls_idx in seq_len(num_classes)) {
+    decoded_boxes[, cls_idx, ] <- decode_boxes(proposals, pred_boxes[, cls_idx, ])
+  }
+
+  # Clip to image boundaries
+  decoded_boxes <- clip_boxes_to_image(decoded_boxes$view(c(-1, 4)), image_size)
+  decoded_boxes <- decoded_boxes$view(c(num_proposals, num_classes, 4))
+
+  # Apply softmax to get class probabilities: [N, num_classes]
+  pred_scores <- torch::nnf_softmax(class_logits, dim = 2)
+
+  # Remove background class (class 1 in 1-based indexing)
+  # Keep classes 2 through num_classes
+  pred_boxes <- pred_boxes[, 2:num_classes, ]      # [N, num_classes-1, 4]
+  pred_scores <- pred_scores[, 2:num_classes]       # [N, num_classes-1]
+
+  num_classes_no_bg <- num_classes - 1L
+
+  # Create labels for each prediction: [num_classes-1]
+  # These are the actual class indices (2, 3, 4, ... num_classes)
+  labels <- torch_arange(2L, num_classes, device = device, dtype = torch_long())
+  # Expand to match scores: [N, num_classes-1]
+  labels <- labels$view(c(1, -1))$expand_as(pred_scores)
+
+  # Flatten everything: treat each (proposal, class) pair as a separate detection
+  boxes <- pred_boxes$reshape(c(-1, 4))           # [N * (num_classes-1), 4]
+  scores <- pred_scores$reshape(c(-1))            # [N * (num_classes-1)]
+  labels <- labels$reshape(c(-1))                 # [N * (num_classes-1)]
+
+  # Remove low scoring boxes
+  keep <- scores > score_thresh
+  boxes <- boxes[keep, ]
+  scores <- scores[keep]
+  labels <- labels[keep]
+
+  if (boxes$shape[1] == 0) {
+    return(list(
+      boxes = torch_empty(c(0, 4), device = device),
+      labels = torch_empty(c(0), dtype = torch_long(), device = device),
+      scores = torch_empty(c(0), device = device)
+    ))
+  }
+
+  # Remove small boxes
+  keep <- remove_small_boxes(boxes, min_size = 1e-2)
+  boxes <- boxes[keep, ]
+  scores <- scores[keep]
+  labels <- labels[keep]
+
+  if (boxes$shape[1] == 0) {
+    return(list(
+      boxes = torch_empty(c(0, 4), device = device),
+      labels = torch_empty(c(0), dtype = torch_long(), device = device),
+      scores = torch_empty(c(0), device = device)
+    ))
+  }
+
+  # Apply per-class NMS
+  keep <- batched_nms(boxes, scores, labels, nms_thresh)
+
+  # Keep only top k detections
+  if (keep$shape[1] > detections_per_img) {
+    keep <- keep[1:detections_per_img]
+  }
+
+  boxes <- boxes[keep, ]
+  scores <- scores[keep]
+  labels <- labels[keep]
+
+  list(boxes = boxes, labels = labels, scores = scores)
+}
+
 #' @importFrom torch nnf_grid_sample torch_empty
 generate_proposals <- function(features, rpn_out, image_size, strides, batch_idx,
                                score_thresh = 0.05, nms_thresh = 0.7) {
@@ -453,59 +556,26 @@ fasterrcnn_model <- torch::nn_module(
             labels = torch_empty(c(0), dtype = torch::torch_long()),
             scores = torch_empty(c(0))
           )
-          return(list(features = features, detections = list(empty)))
+          final_results[[b]] <- empty
+          next
         }
 
-        detections <- self$roi_heads(features, props$proposals, batch_idx = b)
+        # Get ROI head predictions
+        roi_out <- self$roi_heads(features, props$proposals, batch_idx = b)
 
-        scores <- torch::nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch::torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
-
-        box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
-        gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
-        final_boxes <- box_reg$gather(2, gather_idx)$squeeze(2)
-
-        final_boxes <- decode_boxes(props$proposals, final_boxes)
-        final_boxes <- clip_boxes_to_image(final_boxes, image_size)
-
-        # Filter by score threshold AND remove background predictions (class 1)
-        keep <- (final_scores > self$score_thresh) & (final_labels != 1)
-        num_detections <- torch::torch_sum(keep)$item()
-
-        if (num_detections > 0) {
-          final_boxes <- final_boxes[keep, ]
-          final_labels <- final_labels[keep]
-          final_scores <- final_scores[keep]
-
-          # Apply NMS to remove overlapping detections
-          if (final_boxes$shape[1] > 1) {
-            nms_keep <- nms(final_boxes, final_scores, self$nms_thresh)
-            final_boxes <- final_boxes[nms_keep, ]
-            final_labels <- final_labels[nms_keep]
-            final_scores <- final_scores[nms_keep]
-          }
-
-          # Limit detections per image
-          n_det <- final_scores$shape[1]
-          if (n_det > self$detections_per_img) {
-            top_k <- torch::torch_topk(final_scores, self$detections_per_img)
-            top_idx <- top_k[[2]]
-            final_boxes <- final_boxes[top_idx, ]
-            final_labels <- final_labels[top_idx]
-            final_scores <- final_scores[top_idx]
-          }
-        } else {
-          final_boxes <- torch_empty(c(0, 4))
-          final_labels <- torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch_empty(c(0))
-        }
-        final_results[[b]] <- list(
-          boxes = final_boxes,
-          labels = final_labels,
-          scores = final_scores
+        # Postprocess detections
+        result <- postprocess_detections(
+          class_logits = roi_out$scores,
+          box_regression = roi_out$boxes,
+          proposals = props$proposals,
+          image_size = image_size,
+          num_classes = self$num_classes,
+          score_thresh = self$score_thresh,
+          nms_thresh = self$nms_thresh,
+          detections_per_img = self$detections_per_img
         )
+
+        final_results[[b]] <- result
       }
       list(features = features, detections = final_results)
     }
@@ -644,59 +714,26 @@ fasterrcnn_model_v2 <- torch::nn_module(
             labels = torch_empty(c(0), dtype = torch::torch_long()),
             scores = torch_empty(c(0))
           )
-          return(list(features = features, detections = list(empty)))
+          final_results[[b]] <- empty
+          next
         }
 
-        detections <- self$roi_heads(features, props$proposals, batch_idx = b)
+        # Get ROI head predictions
+        roi_out <- self$roi_heads(features, props$proposals, batch_idx = b)
 
-        scores <- nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
-
-        box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
-        gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
-        final_boxes <- box_reg$gather(2, gather_idx)$squeeze(2)
-
-        final_boxes <- decode_boxes(props$proposals, final_boxes)
-        final_boxes <- clip_boxes_to_image(final_boxes, image_size)
-
-        # Filter by score threshold AND remove background predictions (class 1)
-        keep <- (final_scores > self$score_thresh) & (final_labels != 1)
-        num_detections <- torch::torch_sum(keep)$item()
-
-        if (num_detections > 0) {
-          final_boxes <- final_boxes[keep, ]
-          final_labels <- final_labels[keep]
-          final_scores <- final_scores[keep]
-
-          # Apply NMS to remove overlapping detections
-          if (final_boxes$shape[1] > 1) {
-            nms_keep <- nms(final_boxes, final_scores, self$nms_thresh)
-            final_boxes <- final_boxes[nms_keep, ]
-            final_labels <- final_labels[nms_keep]
-            final_scores <- final_scores[nms_keep]
-          }
-
-          # Limit detections per image
-          n_det <- final_scores$shape[1]
-          if (n_det > self$detections_per_img) {
-            top_k <- torch::torch_topk(final_scores, self$detections_per_img)
-            top_idx <- top_k[[2]]
-            final_boxes <- final_boxes[top_idx, ]
-            final_labels <- final_labels[top_idx]
-            final_scores <- final_scores[top_idx]
-          }
-        } else {
-          final_boxes <- torch_empty(c(0, 4))
-          final_labels <- torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch_empty(c(0))
-        }
-        final_results[[b]] <- list(
-          boxes = final_boxes,
-          labels = final_labels,
-          scores = final_scores
+        # Postprocess detections
+        result <- postprocess_detections(
+          class_logits = roi_out$scores,
+          box_regression = roi_out$boxes,
+          proposals = props$proposals,
+          image_size = image_size,
+          num_classes = self$num_classes,
+          score_thresh = self$score_thresh,
+          nms_thresh = self$nms_thresh,
+          detections_per_img = self$detections_per_img
         )
+
+        final_results[[b]] <- result
       }
       list(features = features, detections = final_results)
     }
@@ -805,57 +842,26 @@ fasterrcnn_mobilenet_model <- torch::nn_module(
             labels = torch_empty(c(0), dtype = torch::torch_long()),
             scores = torch_empty(c(0))
           )
-          return(list(features = features, detections = list(empty)))
+          final_results[[b]] <- empty
+          next
         }
 
-        detections <- self$roi_heads(features, props$proposals, batch_idx = b)
+        # Get ROI head predictions
+        roi_out <- self$roi_heads(features, props$proposals, batch_idx = b)
 
-        scores <- nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
-
-        box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
-        gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
-        final_boxes <- box_reg$gather(2, gather_idx)$squeeze(2)
-
-        final_boxes <- decode_boxes(props$proposals, final_boxes)
-        final_boxes <- clip_boxes_to_image(final_boxes, image_size)
-
-        # Filter by score threshold
-        keep <- final_scores > self$score_thresh
-        if (torch::torch_sum(keep)$item() > 0) {
-          final_boxes <- final_boxes[keep, ]
-          final_labels <- final_labels[keep]
-          final_scores <- final_scores[keep]
-
-          # Apply NMS to remove overlapping detections
-          if (final_boxes$shape[1] > 1) {
-            nms_keep <- nms(final_boxes, final_scores, self$nms_thresh)
-            final_boxes <- final_boxes[nms_keep, ]
-            final_labels <- final_labels[nms_keep]
-            final_scores <- final_scores[nms_keep]
-          }
-
-          # Limit detections per image
-          n_det <- final_scores$shape[1]
-          if (n_det > self$detections_per_img) {
-            top_k <- torch::torch_topk(final_scores, self$detections_per_img)
-            top_idx <- top_k[[2]]
-            final_boxes <- final_boxes[top_idx, ]
-            final_labels <- final_labels[top_idx]
-            final_scores <- final_scores[top_idx]
-          }
-        } else {
-          final_boxes <- torch_empty(c(0, 4))
-          final_labels <- torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch_empty(c(0))
-        }
-        final_results[[b]] <- list(
-          boxes = final_boxes,
-          labels = final_labels,
-          scores = final_scores
+        # Postprocess detections
+        result <- postprocess_detections(
+          class_logits = roi_out$scores,
+          box_regression = roi_out$boxes,
+          proposals = props$proposals,
+          image_size = image_size,
+          num_classes = self$num_classes,
+          score_thresh = self$score_thresh,
+          nms_thresh = self$nms_thresh,
+          detections_per_img = self$detections_per_img
         )
+
+        final_results[[b]] <- result
       }
       list(features = features, detections = final_results)
     }

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -117,16 +117,22 @@ generate_level_anchors <- function(h, w, stride, base_sizes = c(32, 64, 128, 256
   anchors$reshape(orig_shape)
 }
 
-decode_boxes <- function(anchors, deltas) {
+decode_boxes <- function(anchors, deltas, weights = c(10.0, 10.0, 5.0, 5.0)) {
   widths <- anchors[, 3] - anchors[, 1]
   heights <- anchors[, 4] - anchors[, 2]
   ctr_x <- anchors[, 1] + widths / 2
   ctr_y <- anchors[, 2] + heights / 2
 
-  dx <- deltas[, 1]
-  dy <- deltas[, 2]
-  dw <- deltas[, 3]
-  dh <- deltas[, 4]
+  # Apply bbox regression weights (default: 10.0, 10.0, 5.0, 5.0)
+  dx <- deltas[, 1] / weights[1]
+  dy <- deltas[, 2] / weights[2]
+  dw <- deltas[, 3] / weights[3]
+  dh <- deltas[, 4] / weights[4]
+
+  # Clamp dw and dh to prevent numerical instability in exp()
+  bbox_xform_clip <- log(1000.0 / 16.0)  # ~4.135
+  dw <- torch::torch_clamp(dw, max = bbox_xform_clip)
+  dh <- torch::torch_clamp(dh, max = bbox_xform_clip)
 
   pred_ctr_x <- ctr_x + dx * widths
   pred_ctr_y <- ctr_y + dy * heights
@@ -147,14 +153,19 @@ decode_boxes <- function(anchors, deltas) {
 #' Keeps all class predictions before filtering, rather than taking max across
 #' classes first, allowing proper per-class NMS.
 #'
-#' @param class_logits Tensor of shape [N, num_classes] - raw classification scores
-#' @param box_regression Tensor of shape [N, num_classes * 4] - box deltas for each class
+#' @param class_logits Tensor of shape [N, num_classes_with_bg] - raw classification scores including background
+#' @param box_regression Tensor of shape [N, num_classes_with_bg * 4] - box deltas for each class
 #' @param proposals Tensor of shape [N, 4] - proposal boxes in (x1, y1, x2, y2) format
 #' @param image_size Integer vector of length 2: [height, width]
-#' @param num_classes Integer - total number of classes including background
+#' @param num_classes Integer - number of classes excluding background (e.g., 90 for COCO)
 #' @param score_thresh Numeric - minimum score threshold for detections
 #' @param nms_thresh Numeric - NMS IoU threshold
 #' @param detections_per_img Integer - maximum detections to return
+#'
+#' @details
+#' Box regression uses standard Faster R-CNN decoding with weights (10, 10, 5, 5).
+#' Background class (index 1 in class_logits) is removed, returning labels
+#' in range [1, num_classes] which correspond to COCO classes [1=person, 2=bicycle, ..., 90=toothbrush].
 #'
 #' @return List with boxes, labels, scores tensors
 #' @noRd
@@ -164,42 +175,45 @@ postprocess_detections <- function(class_logits, box_regression, proposals,
   device <- class_logits$device
   num_proposals <- proposals$shape[1]
 
-  # Decode boxes for all classes: [N, num_classes, 4]
-  pred_boxes <- box_regression$view(c(num_proposals, num_classes, 4))
+  # class_logits and box_regression include background class
+  # num_classes excludes background, so total classes = num_classes + 1
+  num_classes_with_bg <- num_classes + 1L
+
+  # Decode boxes for all classes: [N, num_classes_with_bg, 4]
+  pred_boxes <- box_regression$view(c(num_proposals, num_classes_with_bg, 4))
 
   # Decode boxes using proposals as anchors (expand proposals for all classes)
-  proposals_expanded <- proposals$unsqueeze(2)$expand(c(num_proposals, num_classes, 4))
+  proposals_expanded <- proposals$unsqueeze(2)$expand(c(num_proposals, num_classes_with_bg, 4))
 
   # Decode for each class
   decoded_boxes <- torch_zeros_like(pred_boxes)
-  for (cls_idx in seq_len(num_classes)) {
+  for (cls_idx in seq_len(num_classes_with_bg)) {
     decoded_boxes[, cls_idx, ] <- decode_boxes(proposals, pred_boxes[, cls_idx, ])
   }
 
   # Clip to image boundaries
   decoded_boxes <- clip_boxes_to_image(decoded_boxes$view(c(-1, 4)), image_size)
-  decoded_boxes <- decoded_boxes$view(c(num_proposals, num_classes, 4))
+  decoded_boxes <- decoded_boxes$view(c(num_proposals, num_classes_with_bg, 4))
 
-  # Apply softmax to get class probabilities: [N, num_classes]
+  # Apply softmax to get class probabilities: [N, num_classes_with_bg]
   pred_scores <- torch::nnf_softmax(class_logits, dim = 2)
 
   # Remove background class (class 1 in 1-based indexing)
-  # Keep classes 2 through num_classes
-  pred_boxes <- decoded_boxes[, 2:num_classes, ]   # [N, num_classes-1, 4]
-  pred_scores <- pred_scores[, 2:num_classes]       # [N, num_classes-1]
+  # Keep classes 2 through num_classes_with_bg
+  pred_boxes <- decoded_boxes[, 2:num_classes_with_bg, ]   # [N, num_classes, 4]
+  pred_scores <- pred_scores[, 2:num_classes_with_bg]       # [N, num_classes]
 
-  num_classes_no_bg <- num_classes - 1L
-
-  # Create labels for each prediction: [num_classes-1]
-  # These are the actual class indices (2, 3, 4, ... num_classes)
-  labels <- torch_arange(2L, num_classes, device = device, dtype = torch_long())
-  # Expand to match scores: [N, num_classes-1]
+  # Create labels for each prediction: [num_classes]
+  # These are the actual class indices (1, 2, 3, ... num_classes)
+  # torch_arange in R is inclusive on both ends
+  labels <- torch_arange(1L, num_classes, device = device, dtype = torch_long())
+  # Expand to match scores: [N, num_classes]
   labels <- labels$view(c(1, -1))$expand_as(pred_scores)
 
   # Flatten everything: treat each (proposal, class) pair as a separate detection
-  boxes <- pred_boxes$reshape(c(-1, 4))           # [N * (num_classes-1), 4]
-  scores <- pred_scores$reshape(c(-1))            # [N * (num_classes-1)]
-  labels <- labels$reshape(c(-1))                 # [N * (num_classes-1)]
+  boxes <- pred_boxes$reshape(c(-1, 4))           # [N * num_classes, 4]
+  scores <- pred_scores$reshape(c(-1))            # [N * num_classes]
+  labels <- labels$reshape(c(-1))                 # [N * num_classes]
 
   # Remove low scoring boxes
   keep <- scores > score_thresh
@@ -348,7 +362,10 @@ roi_align <- function(feature_map, proposals, batch_idx, output_size = c(7L, 7L)
 
 roi_heads_module <-  torch::nn_module(
     "region-of-interest head v2",
-    initialize = function(num_classes = 91) {
+    initialize = function(num_classes = 90) {
+      # num_classes excludes background, but predictor needs background + all classes
+      num_classes_with_bg <- num_classes + 1L
+
       # Define box_head with named layers to match expected state dict structure
       self$box_head <- torch::nn_module(
         initialize = function() {
@@ -364,8 +381,8 @@ roi_heads_module <-  torch::nn_module(
 
       self$box_predictor <- torch::nn_module(
         initialize = function() {
-          self$cls_score <- torch::nn_linear(1024, num_classes, bias = TRUE)
-          self$bbox_pred <- torch::nn_linear(1024, num_classes * 4, bias = TRUE)
+          self$cls_score <- torch::nn_linear(1024, num_classes_with_bg, bias = TRUE)
+          self$bbox_pred <- torch::nn_linear(1024, num_classes_with_bg * 4, bias = TRUE)
         },
         forward = function(x) {
           list(
@@ -386,7 +403,10 @@ roi_heads_module <-  torch::nn_module(
 
 roi_heads_module_v2 <- torch::nn_module(
     "region-of-interest head v2",
-    initialize = function(num_classes = 91) {
+    initialize = function(num_classes = 90) {
+      # num_classes excludes background, but predictor needs background + all classes
+      num_classes_with_bg <- num_classes + 1L
+
       # The pretrained weights expect four (Linear -> BN -> ReLU) blocks
       # followed by a final linear layer at index "4".
       block <- function() {
@@ -411,8 +431,8 @@ roi_heads_module_v2 <- torch::nn_module(
       self$box_head <- do.call(nn_sequential, layers)
       self$box_predictor <- torch::nn_module(
         initialize = function() {
-          self$cls_score <- torch::nn_linear(1024, num_classes, bias = TRUE)
-          self$bbox_pred <- torch::nn_linear(1024, num_classes * 4, bias = TRUE)
+          self$cls_score <- torch::nn_linear(1024, num_classes_with_bg, bias = TRUE)
+          self$bbox_pred <- torch::nn_linear(1024, num_classes_with_bg * 4, bias = TRUE)
         },
         forward = function(x) {
           list(
@@ -910,7 +930,7 @@ mobilenet_v3_320_fpn_backbone <- function(pretrained = TRUE) {
 #'
 #' @param pretrained Logical. If TRUE, loads pretrained weights from local file.
 #' @param progress Logical. Show progress bar during download (unused).
-#' @param num_classes Number of output classes (default: 91 for COCO).
+#' @param num_classes Number of output classes excluding background (default: 90 for COCO).
 #' @param score_thresh Numeric. Minimum score threshold for detections (default: 0.05).
 #' @param nms_thresh Numeric. Non-Maximum Suppression (NMS) IoU threshold for removing overlapping boxes (default: 0.5).
 #' @param detections_per_img Integer. Maximum number of detections per image (default: 100).
@@ -1036,7 +1056,7 @@ rpn_model_urls <- list(
 #' @describeIn model_fasterrcnn Faster R-CNN with ResNet-50 FPN
 #' @export
 model_fasterrcnn_resnet50_fpn <- function(pretrained = FALSE, progress = TRUE,
-                                          num_classes = 91,
+                                          num_classes = 90,
                                           score_thresh = 0.05,
                                           nms_thresh = 0.5,
                                           detections_per_img = 100,
@@ -1046,8 +1066,8 @@ model_fasterrcnn_resnet50_fpn <- function(pretrained = FALSE, progress = TRUE,
                             score_thresh = score_thresh,
                             nms_thresh = nms_thresh,
                             detections_per_img = detections_per_img)
-  if (pretrained && num_classes != 91)
-    cli_abort("Pretrained weights require num_classes = 91.")
+  if (pretrained && num_classes != 90)
+    cli_abort("Pretrained weights require num_classes = 90 (excluding background).")
 
   if (pretrained) {
     r <- rpn_model_urls$fasterrcnn_resnet50
@@ -1069,7 +1089,7 @@ model_fasterrcnn_resnet50_fpn <- function(pretrained = FALSE, progress = TRUE,
 #' @describeIn model_fasterrcnn Faster R-CNN with ResNet-50 FPN V2
 #' @export
 model_fasterrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE,
-                                             num_classes = 91,
+                                             num_classes = 90,
                                              score_thresh = 0.05,
                                              nms_thresh = 0.5,
                                              detections_per_img = 100,
@@ -1080,8 +1100,8 @@ model_fasterrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE
                                nms_thresh = nms_thresh,
                                detections_per_img = detections_per_img)
 
-  if (pretrained && num_classes != 91)
-    cli_abort("Pretrained weights require num_classes = 91.")
+  if (pretrained && num_classes != 90)
+    cli_abort("Pretrained weights require num_classes = 90 (excluding background).")
 
   if (pretrained) {
     r <- rpn_model_urls$fasterrcnn_resnet50_v2
@@ -1120,7 +1140,7 @@ model_fasterrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE
 #' @export
 model_fasterrcnn_mobilenet_v3_large_fpn <- function(pretrained = FALSE,
                                                     progress = TRUE,
-                                                    num_classes = 91,
+                                                    num_classes = 90,
                                                     score_thresh = 0.05,
                                                     nms_thresh = 0.5,
                                                     detections_per_img = 100,
@@ -1131,8 +1151,8 @@ model_fasterrcnn_mobilenet_v3_large_fpn <- function(pretrained = FALSE,
                                       nms_thresh = nms_thresh,
                                       detections_per_img = detections_per_img)
 
-  if (pretrained && num_classes != 91)
-    cli_abort("Pretrained weights require num_classes = 91.")
+  if (pretrained && num_classes != 90)
+    cli_abort("Pretrained weights require num_classes = 90 (excluding background).")
 
   if (pretrained) {
     r <- rpn_model_urls$fasterrcnn_mobilenet_v3_large
@@ -1155,7 +1175,7 @@ model_fasterrcnn_mobilenet_v3_large_fpn <- function(pretrained = FALSE,
 #' @export
 model_fasterrcnn_mobilenet_v3_large_320_fpn <- function(pretrained = FALSE,
                                                         progress = TRUE,
-                                                        num_classes = 91,
+                                                        num_classes = 90,
                                                         score_thresh = 0.05,
                                                         nms_thresh = 0.5,
                                                         detections_per_img = 100,
@@ -1166,8 +1186,8 @@ model_fasterrcnn_mobilenet_v3_large_320_fpn <- function(pretrained = FALSE,
                                       nms_thresh = nms_thresh,
                                       detections_per_img = detections_per_img)
 
-  if (pretrained && num_classes != 91)
-    cli_abort("Pretrained weights require num_classes = 91.")
+  if (pretrained && num_classes != 90)
+    cli_abort("Pretrained weights require num_classes = 90 (excluding background).")
 
   if (pretrained) {
     r <- rpn_model_urls$fasterrcnn_mobilenet_v3_large_320

--- a/R/models-faster_rcnn.R
+++ b/R/models-faster_rcnn.R
@@ -964,8 +964,8 @@ mobilenet_v3_320_fpn_backbone <- function(pretrained = TRUE) {
 #' @examples
 #' \dontrun{
 #' library(magrittr)
-#' norm_mean <- c(0.485, 0.456, 0.406) # ImageNet normalization constants, see
-#' # https://pytorch.org/vision/stable/models.html
+#' # ImageNet normalization constants, see https://pytorch.org/vision/stable/models.html
+#' norm_mean <- c(0.485, 0.456, 0.406)
 #' norm_std  <- c(0.229, 0.224, 0.225)
 #' # Use a publicly available image of an animal
 #' url <- paste0("https://upload.wikimedia.org/wikipedia/commons/thumb/",
@@ -979,17 +979,15 @@ mobilenet_v3_320_fpn_backbone <- function(pretrained = TRUE) {
 #' batch_normalized <- input$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
 #'
 #' # ResNet-50 FPN V2
-#' model <- model_fasterrcnn_resnet50_fpn_v2(pretrained = TRUE)
+#' model <- model_fasterrcnn_resnet50_fpn_v2(pretrained = TRUE, , detections_per_img = 5 )
 #' model$eval()
 #' torch::with_no_grad({pred <- model(batch_normalized)$detections[[1]]})
-#' num_boxes <- as.integer(pred$boxes$size()[1])
-#' keep <- seq_len(min(5, num_boxes))
-#' boxes <- pred$boxes[keep, ]$view(c(-1, 4))
-#' labels <- coco_classes(as.integer(pred$labels[keep]))
-#' if (num_boxes > 0) {
-#'   boxed <- draw_bounding_boxes(image, boxes, labels = labels)
-#'   tensor_image_browse(boxed)
-#' }
+#' labels <- coco_classes(as.integer(pred$labels))
+#'
+#' # Visualize boxes
+#' labels <- coco_classes(as.integer(pred$labels))
+#' boxed <- draw_bounding_boxes(image, pred$boxes, labels = labels)
+#' tensor_image_browse(boxed)
 #'
 #' # MobileNet V3 Large 320 FPN
 #' batch <- image$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
@@ -998,14 +996,11 @@ mobilenet_v3_320_fpn_backbone <- function(pretrained = TRUE) {
 #' )
 #' model$eval()
 #' torch::with_no_grad({pred <- model(batch)$detections[[1]]})
-#' num_boxes <- as.integer(pred$boxes$size()[1])
-#' keep <- seq_len(min(5, num_boxes))
-#' boxes <- pred$boxes[keep, ]$view(c(-1, 4))
-#' labels <- coco_classes(as.integer(pred$labels[keep]))
-#' if (num_boxes > 0) {
-#'   boxed <- draw_bounding_boxes(image, boxes, labels = labels)
-#'   tensor_image_browse(boxed)
-#' }
+#'
+#' # Visualize boxes
+#' labels <- coco_classes(as.integer(pred$labels))
+#' boxed <- draw_bounding_boxes(image, pred$boxes, labels = labels)
+#' tensor_image_browse(boxed)
 #' }
 #'
 #' @family object_detection_model

--- a/R/models-mask_rcnn.R
+++ b/R/models-mask_rcnn.R
@@ -279,7 +279,6 @@ maskrcnn_model <- torch::nn_module(
       features <- self$backbone(images)
       rpn_out <- self$rpn(features)
 
-
       batch_size <- images$shape[1]
       image_size <- images$shape[3:4]
       final_results <- list()
@@ -297,123 +296,44 @@ maskrcnn_model <- torch::nn_module(
             scores = torch::torch_empty(c(0)),
             masks = torch::torch_empty(c(0, 28, 28))
           )
-          return(list(features = features, detections = list(empty)))
+          final_results[[b]] <- empty
+          next
         }
 
-        # Limit proposals to avoid slow ROI pooling (common practice in detection)
+        # Limit proposals to avoid slow ROI pooling
         max_proposals <- 1000
         if (props$proposals$shape[1] > max_proposals) {
           props$proposals <- props$proposals[1:max_proposals, ]
         }
 
-        # Box predictions
-        detections <- self$roi_heads(features, props$proposals, batch_idx = b)
+        # Get ROI head predictions
+        roi_out <- self$roi_heads(features, props$proposals, batch_idx = b)
 
-        scores <- torch::nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch::torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
+        # Postprocess detections
+        det_result <- postprocess_detections(
+          class_logits = roi_out$scores,
+          box_regression = roi_out$boxes,
+          proposals = props$proposals,
+          image_size = image_size,
+          num_classes = self$num_classes,
+          score_thresh = self$score_thresh,
+          nms_thresh = self$nms_thresh,
+          detections_per_img = self$detections_per_img
+        )
 
-        box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
-        gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
-        # 'deltas' now contains the predicted dx, dy, dw, dh for the best class
-        deltas <- box_reg$gather(2, gather_idx)$squeeze(2)
+        final_boxes <- det_result$boxes
+        final_labels <- det_result$labels
+        final_scores <- det_result$scores
 
-        # Filter by score threshold AND remove background predictions (class 1)
-        keep <- (final_scores > self$score_thresh) & (final_labels != 1)
-        num_detections <- torch::torch_sum(keep)$item()
+        # Predict masks for detected objects
+        if (final_boxes$shape[1] > 0) {
+          # For mask prediction, we need to map final boxes back to proposals
+          # Since postprocess_detections decodes boxes, we need the original proposals
+          # that correspond to the kept detections. We'll use the final_boxes directly.
 
-        if (num_detections > 0) {
-          # Apply filters to deltas, scores, labels, and proposals
-          final_deltas <- deltas[keep, ]
-          final_scores <- final_scores[keep]
-          final_labels <- final_labels[keep]
-
-          # We need the proposals that correspond to these kept detections
-          # 'props$proposals' are the reference boxes (anchors)
-          kept_proposals <- props$proposals[keep, ]
-
-          # 3. Decode Deltas to Absolute Coordinates
-          # Formula: pred_box = proposal + delta
-          # Standard Faster R-CNN decoding:
-
-          # Widths and Heights of proposals
-          widths <- kept_proposals[, 3] - kept_proposals[, 1]
-          heights <- kept_proposals[, 4] - kept_proposals[, 2]
-
-          # Centers of proposals
-          ctr_x <- kept_proposals[, 1] + 0.5 * widths
-          ctr_y <- kept_proposals[, 2] + 0.5 * heights
-
-          # Extract predicted deltas
-          dx <- final_deltas[, 1]
-          dy <- final_deltas[, 2]
-          dw <- final_deltas[, 3]
-          dh <- final_deltas[, 4]
-
-          # Apply deltas
-          pred_ctr_x <- dx * widths + ctr_x
-          pred_ctr_y <- dy * heights + ctr_y
-          pred_w <- torch_exp(dw) * widths
-          pred_h <- torch_exp(dh) * heights
-
-          # Convert back to (x1, y1, x2, y2)
-          final_boxes <- torch_zeros_like(final_deltas)
-          final_boxes[, 1] <- pred_ctr_x - 0.5 * pred_w # x1
-          final_boxes[, 2] <- pred_ctr_y - 0.5 * pred_h # y1
-          final_boxes[, 3] <- pred_ctr_x + 0.5 * pred_w # x2
-          final_boxes[, 4] <- pred_ctr_y + 0.5 * pred_h # y2
-
-          # Clip Boxes to Image Boundary
-          img_h <- images$shape[3]
-          img_w <- images$shape[4]
-
-          final_boxes <- torch_clamp(final_boxes, min = 0.0)
-          img_w_tensor <- torch_tensor(img_w, device = final_boxes$device)
-          img_h_tensor <- torch_tensor(img_h, device = final_boxes$device)
-          final_boxes[, 1] <- torch_minimum(final_boxes[, 1], img_w_tensor)
-          final_boxes[, 2] <- torch_minimum(final_boxes[, 2], img_h_tensor)
-          final_boxes[, 3] <- torch_minimum(final_boxes[, 3], img_w_tensor)
-          final_boxes[, 4] <- torch_minimum(final_boxes[, 4], img_h_tensor)
-
-          # Apply NMS and Limit Detections
-          if (final_boxes$shape[1] > 0L) {
-            nms_keep <- nms(final_boxes, final_scores, self$nms_thresh)
-            final_boxes <- final_boxes[nms_keep, ]
-            final_labels <- final_labels[nms_keep]
-            final_scores <- final_scores[nms_keep]
-            kept_proposals <- kept_proposals[nms_keep, ]
-          }
-
-          # drop degenerate boxes before ROI‑Align
-          valid_boxes_mask <- (kept_proposals[,3] > kept_proposals[,1]) &
-            (kept_proposals[,4] > kept_proposals[,2])
-
-          if (valid_boxes_mask$sum()$item() == 0L) {
-            # nothing to pool → empty mask tensor
-            final_masks <- torch::torch_empty(c(0, 28, 28))
-          } else {
-            final_boxes <- final_boxes[valid_boxes_mask, ]
-            final_labels <- final_labels[valid_boxes_mask]
-            final_scores <- final_scores[valid_boxes_mask]
-            kept_proposals <- kept_proposals[valid_boxes_mask, ]
-          }
-
-          # Limit detections per image
-          n_det <- final_scores$shape[1]
-          if (n_det > self$detections_per_img) {
-            top_k <- torch::torch_topk(final_scores, self$detections_per_img)
-            top_idx <- top_k[[2]]
-            final_boxes <- final_boxes[top_idx, ]
-            final_labels <- final_labels[top_idx]
-            final_scores <- final_scores[top_idx]
-            kept_proposals <- kept_proposals[top_idx, ]
-          }
-
-          # Predict masks for kept detections
           mask_features <- roi_align_masks_fpn(
             feature_maps = features,
-            proposals    = kept_proposals,
+            proposals    = final_boxes,
             output_size  = c(14L, 14L),
             sampling_ratio = 2L,
             aligned        = FALSE
@@ -423,7 +343,7 @@ maskrcnn_model <- torch::nn_module(
 
           # Extract masks for predicted classes
           n_kept <- final_labels$shape[1]
-          final_masks <- torch::torch_zeros(c(n_kept, 28, 28))
+          final_masks <- torch::torch_zeros(c(n_kept, 28, 28), device = final_boxes$device)
 
           for (i in seq_len(n_kept)) {
             class_idx <- as.integer(final_labels[i]$item())
@@ -434,11 +354,9 @@ maskrcnn_model <- torch::nn_module(
           final_masks <- torch::torch_sigmoid(final_masks)
 
         } else {
-          final_boxes <- torch::torch_empty(c(0, 4))
-          final_labels <- torch::torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch::torch_empty(c(0))
           final_masks <- torch::torch_empty(c(0, 28, 28))
         }
+
         final_results[[b]] <- list(
           boxes = final_boxes,
           labels = final_labels,
@@ -508,125 +426,45 @@ maskrcnn_model_v2 <- torch::nn_module(
           next
         }
 
-        # Limit proposals to avoid slow ROI pooling (common practice in detection)
+        # Limit proposals to avoid slow ROI pooling
         max_proposals <- 1000
         if (props$proposals$shape[1] > max_proposals) {
           props$proposals <- props$proposals[1:max_proposals, ]
         }
 
-        # Box predictions
-        detections <- self$roi_heads(features, props$proposals, batch_idx = b)
+        # Get ROI head predictions
+        roi_out <- self$roi_heads(features, props$proposals, batch_idx = b)
 
-        scores <- torch::nnf_softmax(detections$scores, dim = 2)
-        max_scores <- torch::torch_max(scores, dim = 2)
-        final_scores <- max_scores[[1]]
-        final_labels <- max_scores[[2]]
+        # Postprocess detections
+        det_result <- postprocess_detections(
+          class_logits = roi_out$scores,
+          box_regression = roi_out$boxes,
+          proposals = props$proposals,
+          image_size = image_size,
+          num_classes = self$num_classes,
+          score_thresh = self$score_thresh,
+          nms_thresh = self$nms_thresh,
+          detections_per_img = self$detections_per_img
+        )
 
-        box_reg <- detections$boxes$view(c(-1, self$num_classes, 4))
-        gather_idx <- final_labels$unsqueeze(2)$unsqueeze(3)$expand(c(-1, 1, 4))
-        # 'deltas' now contains the predicted dx, dy, dw, dh for the best class
-        deltas <- box_reg$gather(2, gather_idx)$squeeze(2)
+        final_boxes <- det_result$boxes
+        final_labels <- det_result$labels
+        final_scores <- det_result$scores
 
-        # Filter by score threshold
-        keep <- final_scores > self$score_thresh
-        num_detections <- torch::torch_sum(keep)$item()
-
-        if (num_detections > 0) {
-          # Apply filters to deltas, scores, labels, and proposals
-          final_deltas <- deltas[keep, ]
-          final_scores <- final_scores[keep]
-          final_labels <- final_labels[keep]
-          kept_proposals <- props$proposals[keep, ]
-
-          # Decode Deltas to Absolute Coordinates $pred_box = proposal + delta$
-
-          # Widths and Heights of proposals
-          widths <- kept_proposals[, 3] - kept_proposals[, 1]
-          heights <- kept_proposals[, 4] - kept_proposals[, 2]
-
-          # Centers of proposals
-          ctr_x <- kept_proposals[, 1] + 0.5 * widths
-          ctr_y <- kept_proposals[, 2] + 0.5 * heights
-
-          # Extract predicted deltas
-          dx <- final_deltas[, 1]
-          dy <- final_deltas[, 2]
-          dw <- final_deltas[, 3]
-          dh <- final_deltas[, 4]
-
-          # Apply deltas
-          pred_ctr_x <- dx * widths + ctr_x
-          pred_ctr_y <- dy * heights + ctr_y
-          pred_w <- torch_exp(dw) * widths
-          pred_h <- torch_exp(dh) * heights
-
-          # Convert back to (x1, y1, x2, y2)
-          final_boxes <- torch_zeros_like(final_deltas)
-          final_boxes[, 1] <- pred_ctr_x - 0.5 * pred_w # x1
-          final_boxes[, 2] <- pred_ctr_y - 0.5 * pred_h # y1
-          final_boxes[, 3] <- pred_ctr_x + 0.5 * pred_w # x2
-          final_boxes[, 4] <- pred_ctr_y + 0.5 * pred_h # y2
-
-          # Clip Boxes to Image Boundary
-          img_h <- images$shape[3]
-          img_w <- images$shape[4]
-
-          final_boxes <- torch_clamp(final_boxes, min = 0.0)
-          img_w_tensor <- torch_tensor(img_w, device = final_boxes$device)
-          img_h_tensor <- torch_tensor(img_h, device = final_boxes$device)
-          final_boxes[, 1] <- torch_minimum(final_boxes[, 1], img_w_tensor)
-          final_boxes[, 2] <- torch_minimum(final_boxes[, 2], img_h_tensor)
-          final_boxes[, 3] <- torch_minimum(final_boxes[, 3], img_w_tensor)
-          final_boxes[, 4] <- torch_minimum(final_boxes[, 4], img_h_tensor)
-
-          # Apply NMS and Limit Detections
-          if (final_boxes$shape[1] > 1L) {
-            nms_keep <- nms(final_boxes, final_scores, self$nms_thresh)
-            final_boxes <- final_boxes[nms_keep, ]
-            final_labels <- final_labels[nms_keep]
-            final_scores <- final_scores[nms_keep]
-            kept_proposals <- kept_proposals[nms_keep, ]
-          }
-
-
-          # drop degenerate boxes before ROI‑Align
-          valid_boxes_mask <- (kept_proposals[,3] > kept_proposals[,1]) &
-            (kept_proposals[,4] > kept_proposals[,2])
-
-          if (valid_boxes_mask$sum()$item() == 0L) {
-            # nothing to pool → empty mask tensor
-            final_masks <- torch::torch_empty(c(0, 28, 28))
-          } else {
-            final_boxes <- final_boxes[valid_boxes_mask, ]
-            final_labels <- final_labels[valid_boxes_mask]
-            final_scores <- final_scores[valid_boxes_mask]
-            kept_proposals <- kept_proposals[valid_boxes_mask, ]
-          }
-
-          # Limit detections per image
-          n_det <- final_scores$shape[1]
-          if (n_det > self$detections_per_img) {
-            top_k <- torch::torch_topk(final_scores, self$detections_per_img)
-            top_idx <- top_k[[2]]
-            final_boxes <- final_boxes[top_idx, ]
-            final_labels <- final_labels[top_idx]
-            final_scores <- final_scores[top_idx]
-            kept_proposals <- kept_proposals[top_idx, ]
-          }
-
-          # Predict masks for kept detections
+        # Predict masks for detected objects
+        if (final_boxes$shape[1] > 0) {
           mask_features <- roi_align_masks_fpn(
             feature_maps = features,
-            proposals    = kept_proposals,      # still in image space
+            proposals    = final_boxes,
             output_size  = c(14L, 14L),
             sampling_ratio = 2L,
             aligned        = FALSE
           )
-          mask_logits   <- self$mask_head(mask_features)       # (N, num_classes, 28, 28)
+          mask_logits <- self$mask_head(mask_features)  # (N, num_classes, 28, 28)
 
           # Extract masks for predicted classes
           n_kept <- final_labels$shape[1]
-          final_masks <- torch::torch_zeros(c(n_kept, 28, 28))
+          final_masks <- torch::torch_zeros(c(n_kept, 28, 28), device = final_boxes$device)
 
           for (i in seq_len(n_kept)) {
             class_idx <- as.integer(final_labels[i]$item())
@@ -637,11 +475,9 @@ maskrcnn_model_v2 <- torch::nn_module(
           final_masks <- torch::torch_sigmoid(final_masks)
 
         } else {
-          final_boxes <- torch::torch_empty(c(0, 4))
-          final_labels <- torch::torch_empty(c(0), dtype = torch::torch_long())
-          final_scores <- torch::torch_empty(c(0))
           final_masks <- torch::torch_empty(c(0, 28, 28))
         }
+
         final_results[[b]] <- list(
           boxes = final_boxes,
           labels = final_labels,

--- a/R/models-mask_rcnn.R
+++ b/R/models-mask_rcnn.R
@@ -141,6 +141,10 @@ roi_align_masks <- function(feature_map,
   sampling_x <- x1$view(c(-1, 1, 1)) + rel_x$view(c(1, output_size[1], output_size[2])) * (x2 - x1)$view(c(-1, 1, 1))
   sampling_y <- y1$view(c(-1, 1, 1)) + rel_y$view(c(1, output_size[1], output_size[2])) * (y2 - y1)$view(c(-1, 1, 1))
 
+  # Clamp grid to [-1, 1] to avoid needing padding (especially for MPS compatibility)
+  sampling_x <- sampling_x$clamp(-1, 1)
+  sampling_y <- sampling_y$clamp(-1, 1)
+
   # Concat to get a grid of [N, output_size[1], output_size[2], 2]
   grid <- torch_stack(list(sampling_x, sampling_y), dim = -1)
 
@@ -152,7 +156,7 @@ roi_align_masks <- function(feature_map,
     input_expanded,
     grid,
     mode = "bilinear",
-    padding_mode = "border",
+    padding_mode = "zeros",
     align_corners = FALSE
   )
 
@@ -283,7 +287,7 @@ maskrcnn_model <- torch::nn_module(
       for (b in seq_len(batch_size)) {
 
         props <- generate_proposals(features, rpn_out, image_size, c(4, 8, 16, 32),
-                                    batch_idx = b, score_thresh = self$score_thresh,
+                                    batch_idx = b, score_thresh = 0,
                                     nms_thresh = self$nms_thresh)
 
         if (props$proposals$shape[1] == 0) {
@@ -315,8 +319,8 @@ maskrcnn_model <- torch::nn_module(
         # 'deltas' now contains the predicted dx, dy, dw, dh for the best class
         deltas <- box_reg$gather(2, gather_idx)$squeeze(2)
 
-        # Filter by score threshold before decoding
-        keep <- final_scores > self$score_thresh
+        # Filter by score threshold AND remove background predictions (class 1)
+        keep <- (final_scores > self$score_thresh) & (final_labels != 1)
         num_detections <- torch::torch_sum(keep)$item()
 
         if (num_detections > 0) {
@@ -365,10 +369,12 @@ maskrcnn_model <- torch::nn_module(
           img_w <- images$shape[4]
 
           final_boxes <- torch_clamp(final_boxes, min = 0.0)
-          final_boxes[, 1] <- torch_minimum(final_boxes[, 1], img_w)
-          final_boxes[, 2] <- torch_minimum(final_boxes[, 2], img_h)
-          final_boxes[, 3] <- torch_minimum(final_boxes[, 3], img_w)
-          final_boxes[, 4] <- torch_minimum(final_boxes[, 4], img_h)
+          img_w_tensor <- torch_tensor(img_w, device = final_boxes$device)
+          img_h_tensor <- torch_tensor(img_h, device = final_boxes$device)
+          final_boxes[, 1] <- torch_minimum(final_boxes[, 1], img_w_tensor)
+          final_boxes[, 2] <- torch_minimum(final_boxes[, 2], img_h_tensor)
+          final_boxes[, 3] <- torch_minimum(final_boxes[, 3], img_w_tensor)
+          final_boxes[, 4] <- torch_minimum(final_boxes[, 4], img_h_tensor)
 
           # Apply NMS and Limit Detections
           if (final_boxes$shape[1] > 0L) {
@@ -488,7 +494,7 @@ maskrcnn_model_v2 <- torch::nn_module(
 
       for (b in seq_len(batch_size)) {
         props <- generate_proposals(features, rpn_out, image_size, c(4, 8, 16, 32),
-                                    batch_idx = b, score_thresh = self$score_thresh,
+                                    batch_idx = b, score_thresh = 0,
                                     nms_thresh = self$nms_thresh)
 
         if (props$proposals$shape[1] == 0L) {
@@ -566,10 +572,12 @@ maskrcnn_model_v2 <- torch::nn_module(
           img_w <- images$shape[4]
 
           final_boxes <- torch_clamp(final_boxes, min = 0.0)
-          final_boxes[, 1] <- torch_minimum(final_boxes[, 1], img_w)
-          final_boxes[, 2] <- torch_minimum(final_boxes[, 2], img_h)
-          final_boxes[, 3] <- torch_minimum(final_boxes[, 3], img_w)
-          final_boxes[, 4] <- torch_minimum(final_boxes[, 4], img_h)
+          img_w_tensor <- torch_tensor(img_w, device = final_boxes$device)
+          img_h_tensor <- torch_tensor(img_h, device = final_boxes$device)
+          final_boxes[, 1] <- torch_minimum(final_boxes[, 1], img_w_tensor)
+          final_boxes[, 2] <- torch_minimum(final_boxes[, 2], img_h_tensor)
+          final_boxes[, 3] <- torch_minimum(final_boxes[, 3], img_w_tensor)
+          final_boxes[, 4] <- torch_minimum(final_boxes[, 4], img_h_tensor)
 
           # Apply NMS and Limit Detections
           if (final_boxes$shape[1] > 1L) {

--- a/R/models-mask_rcnn.R
+++ b/R/models-mask_rcnn.R
@@ -27,7 +27,7 @@ mask_head_module <- torch::nn_module(
 # Mask RCNN predictor - Predicts segmentation masks for detected objects
 mask_rcnn_predictor <- torch::nn_module(
     "mask_rcnn_predictor",
-    initialize = function(num_classes = 91) {
+    initialize = function(num_classes = 90) {
       # Deconvolution layer to upsample from 14x14 to 28x28
       self$conv5_mask <- nn_conv_transpose2d(256, 256, kernel_size = 2, stride = 2)
 
@@ -43,7 +43,7 @@ mask_rcnn_predictor <- torch::nn_module(
 # Mask Head Module V2 - With batch normalization
 mask_head_module_v2 <- torch::nn_module(
     "mask_head_v2",
-    initialize = function(num_classes = 91) {
+    initialize = function(num_classes = 90) {
       # Convolutional blocks with batch normalization
       conv_block <- function() {
         nn_sequential(
@@ -588,7 +588,7 @@ mask_rcnn_model_urls <- list(
 #' @describeIn model_maskrcnn Mask R-CNN with ResNet-50 FPN
 #' @export
 model_maskrcnn_resnet50_fpn <- function(pretrained = FALSE, progress = TRUE,
-                                        num_classes = 91,
+                                        num_classes = 90,
                                         score_thresh = 0.05,
                                         nms_thresh = 0.5,
                                         detections_per_img = 100,
@@ -600,7 +600,7 @@ model_maskrcnn_resnet50_fpn <- function(pretrained = FALSE, progress = TRUE,
                          detections_per_img = detections_per_img)
 
   if (pretrained && num_classes != 91)
-    cli_abort("Pretrained weights require num_classes = 91.")
+    cli_abort("Pretrained weights require num_classes = 90.")
 
   if (pretrained) {
     r <- mask_rcnn_model_urls$maskrcnn_resnet50
@@ -622,7 +622,7 @@ model_maskrcnn_resnet50_fpn <- function(pretrained = FALSE, progress = TRUE,
 #' @describeIn model_maskrcnn Mask R-CNN with ResNet-50 FPN V2
 #' @export
 model_maskrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE,
-                                           num_classes = 91,
+                                           num_classes = 90,
                                            score_thresh = 0.05,
                                            nms_thresh = 0.5,
                                            detections_per_img = 100,
@@ -634,7 +634,7 @@ model_maskrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE,
                             detections_per_img = detections_per_img)
 
   if (pretrained && num_classes != 91)
-    cli_abort("Pretrained weights require num_classes = 91.")
+    cli_abort("Pretrained weights require num_classes = 90.")
 
   if (pretrained) {
     r <- mask_rcnn_model_urls$maskrcnn_resnet50_v2

--- a/R/models-mask_rcnn.R
+++ b/R/models-mask_rcnn.R
@@ -28,11 +28,14 @@ mask_head_module <- torch::nn_module(
 mask_rcnn_predictor <- torch::nn_module(
     "mask_rcnn_predictor",
     initialize = function(num_classes = 90) {
+      # num_classes excludes background, but predictor needs background + all classes
+      num_classes_with_bg <- num_classes + 1L
+
       # Deconvolution layer to upsample from 14x14 to 28x28
       self$conv5_mask <- nn_conv_transpose2d(256, 256, kernel_size = 2, stride = 2)
 
       # Final 1x1 conv for class-specific mask logits
-      self$mask_fcn_logits <- nn_conv2d(256, num_classes, kernel_size = 1)
+      self$mask_fcn_logits <- nn_conv2d(256, num_classes_with_bg, kernel_size = 1)
     },
     forward = function(x) {
       x <- nnf_relu(self$conv5_mask(x))
@@ -44,6 +47,9 @@ mask_rcnn_predictor <- torch::nn_module(
 mask_head_module_v2 <- torch::nn_module(
     "mask_head_v2",
     initialize = function(num_classes = 90) {
+      # num_classes excludes background, but predictor needs background + all classes
+      num_classes_with_bg <- num_classes + 1L
+
       # Convolutional blocks with batch normalization
       conv_block <- function() {
         nn_sequential(
@@ -65,7 +71,7 @@ mask_head_module_v2 <- torch::nn_module(
       )
 
       # Final 1x1 conv for class-specific mask logits
-      self$mask_predictor.mask_fcn_logits <- nn_conv2d(256, num_classes, kernel_size = 1)
+      self$mask_predictor.mask_fcn_logits <- nn_conv2d(256, num_classes_with_bg, kernel_size = 1)
     },
     forward = function(x) {
       x <- self$mask_head.0(x)
@@ -498,7 +504,7 @@ maskrcnn_model_v2 <- torch::nn_module(
 #'
 #' @param pretrained Logical. If TRUE, loads pretrained weights from local file.
 #' @param progress Logical. Show progress bar during download (unused).
-#' @param num_classes Number of output classes (default: 91 for COCO).
+#' @param num_classes Number of output classes excluding background (default: 90 for COCO).
 #' @param score_thresh Numeric. Minimum score threshold for detections (default: 0.05).
 #' @param nms_thresh Numeric. Non-Maximum Suppression (NMS) IoU threshold for removing overlapping boxes (default: 0.5).
 #' @param detections_per_img Integer. Maximum number of detections per image (default: 100).
@@ -599,8 +605,8 @@ model_maskrcnn_resnet50_fpn <- function(pretrained = FALSE, progress = TRUE,
                          nms_thresh = nms_thresh,
                          detections_per_img = detections_per_img)
 
-  if (pretrained && num_classes != 91)
-    cli_abort("Pretrained weights require num_classes = 90.")
+  if (pretrained && num_classes != 90)
+    cli_abort("Pretrained weights require num_classes = 90 (excluding background).")
 
   if (pretrained) {
     r <- mask_rcnn_model_urls$maskrcnn_resnet50
@@ -633,8 +639,8 @@ model_maskrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE,
                             nms_thresh = nms_thresh,
                             detections_per_img = detections_per_img)
 
-  if (pretrained && num_classes != 91)
-    cli_abort("Pretrained weights require num_classes = 90.")
+  if (pretrained && num_classes != 90)
+    cli_abort("Pretrained weights require num_classes = 90 (excluding background).")
 
   if (pretrained) {
     r <- mask_rcnn_model_urls$maskrcnn_resnet50_v2

--- a/R/models-mask_rcnn.R
+++ b/R/models-mask_rcnn.R
@@ -546,6 +546,7 @@ maskrcnn_model_v2 <- torch::nn_module(
 #' @examples
 #' \dontrun{
 #' library(magrittr)
+#' # ImageNet normalization constants, see https://pytorch.org/vision/stable/models.html
 #' norm_mean <- c(0.485, 0.456, 0.406)
 #' norm_std  <- c(0.229, 0.224, 0.225)
 #'
@@ -561,22 +562,16 @@ maskrcnn_model_v2 <- torch::nn_module(
 #' batch <- input$unsqueeze(1)
 #'
 #' # Mask R-CNN ResNet-50 FPN
-#' model <- model_maskrcnn_resnet50_fpn(pretrained = TRUE)
+#' model <- model_maskrcnn_resnet50_fpn(pretrained = TRUE, , detections_per_img = 5)
 #' model$eval()
-#' pred <- model(batch)$detections
 #'
-#' # Access predictions
-#' boxes <- pred$boxes
-#' labels <- pred$labels
-#' scores <- pred$scores
-#' masks <- pred$masks  # Segmentation masks (N, 28, 28)
+#' torch::with_no_grad({pred <- model(batch)$detections[[1]]})
 #'
 #' # Visualize boxes
-#' if (boxes$size(1) > 0) {
-#'   boxed <- draw_bounding_boxes(input, boxes[1:5, ])
-#'   tensor_image_browse(boxed)
-#' }
-#' }
+#' labels <- coco_classes(as.integer(pred$labels))
+#' boxed <- draw_bounding_boxes(image, pred$boxes, labels = labels)
+#' tensor_image_browse(boxed)
+#'}
 #'
 #' @family object_detection_model
 #' @name model_maskrcnn

--- a/R/models-mask_rcnn.R
+++ b/R/models-mask_rcnn.R
@@ -353,7 +353,10 @@ maskrcnn_model <- torch::nn_module(
 
           for (i in seq_len(n_kept)) {
             class_idx <- as.integer(final_labels[i]$item())
-            final_masks[i, , ] <- mask_logits[i, class_idx, , ]
+            # mask_logits has channels [background, class1, ..., class90]
+            # labels are [1, 2, ..., 90], so we need to skip channel 1 (background)
+            # In 1-based R indexing: label 1 should access channel 2 (class 1)
+            final_masks[i, , ] <- mask_logits[i, class_idx + 1L, , ]
           }
 
           # Apply sigmoid to get probabilities
@@ -474,7 +477,10 @@ maskrcnn_model_v2 <- torch::nn_module(
 
           for (i in seq_len(n_kept)) {
             class_idx <- as.integer(final_labels[i]$item())
-            final_masks[i, , ] <- mask_logits[i, class_idx, , ]
+            # mask_logits has channels [background, class1, ..., class90]
+            # labels are [1, 2, ..., 90], so we need to skip channel 1 (background)
+            # In 1-based R indexing: label 1 should access channel 2 (class 1)
+            final_masks[i, , ] <- mask_logits[i, class_idx + 1L, , ]
           }
 
           # Apply sigmoid to get probabilities
@@ -653,6 +659,9 @@ model_maskrcnn_resnet50_fpn_v2 <- function(pretrained = FALSE, progress = TRUE,
     }
 
     state_dict <- torch::load_state_dict(state_dict_path)
+
+    # Rename state dict keys to match model structure
+    state_dict <- .rename_maskrcnn_state_dict_v2(state_dict)
 
     # Load with flexible matching (similar to fasterrcnn_v2)
     model_state <- model$state_dict()

--- a/R/ops-boxes.R
+++ b/R/ops-boxes.R
@@ -45,6 +45,11 @@ nms <- function(boxes, scores, iou_threshold) {
   keep[1] <- 1L
   n_keep <- 1L
 
+  # Handle single box case
+  if (n_boxes == 1) {
+    return(order[1:1])
+  }
+
   for (i in 2:n_boxes) {
     # Get current box - use unsqueeze to ensure 2D tensor [1, 4]
     current_box <- sorted_boxes[i, ]$unsqueeze(1)

--- a/man/coco_classes.Rd
+++ b/man/coco_classes.Rd
@@ -4,7 +4,7 @@
 \alias{coco_classes}
 \title{MS COCO Class Labels}
 \usage{
-coco_classes(class_id = 1:81)
+coco_classes(class_id = 1:90)
 }
 \arguments{
 \item{class_id}{Integer vector of 1-based class identifiers.}
@@ -13,8 +13,9 @@ coco_classes(class_id = 1:81)
 A character vector with the COCO class names
 }
 \description{
-Utilities for resolving COCO 81 class identifiers to their corresponding
-human readable labels. The labels are retrieved from ultralytics source
+Utilities for resolving COCO 90 class identifiers to their corresponding
+human readable labels. The labels are retrieved from pytorch/vision source to be compliant
+with torchvision pretrained models.
 }
 \seealso{
 Other class_resolution: 

--- a/man/model_convnext_detection.Rd
+++ b/man/model_convnext_detection.Rd
@@ -26,7 +26,7 @@ model_convnext_base_detection(
 )
 }
 \arguments{
-\item{num_classes}{Number of output classes (default: 91 for COCO).}
+\item{num_classes}{Number of output classes excluding background (default: 90 for COCO).}
 
 \item{pretrained_backbone}{Logical. If \code{TRUE}, loads ImageNet-pretrained
 ConvNeXt backbone weights. Default: \code{FALSE}.}

--- a/man/model_fasterrcnn.Rd
+++ b/man/model_fasterrcnn.Rd
@@ -11,7 +11,7 @@
 model_fasterrcnn_resnet50_fpn(
   pretrained = FALSE,
   progress = TRUE,
-  num_classes = 91,
+  num_classes = 90,
   score_thresh = 0.05,
   nms_thresh = 0.5,
   detections_per_img = 100,
@@ -21,7 +21,7 @@ model_fasterrcnn_resnet50_fpn(
 model_fasterrcnn_resnet50_fpn_v2(
   pretrained = FALSE,
   progress = TRUE,
-  num_classes = 91,
+  num_classes = 90,
   score_thresh = 0.05,
   nms_thresh = 0.5,
   detections_per_img = 100,
@@ -31,7 +31,7 @@ model_fasterrcnn_resnet50_fpn_v2(
 model_fasterrcnn_mobilenet_v3_large_fpn(
   pretrained = FALSE,
   progress = TRUE,
-  num_classes = 91,
+  num_classes = 90,
   score_thresh = 0.05,
   nms_thresh = 0.5,
   detections_per_img = 100,
@@ -41,7 +41,7 @@ model_fasterrcnn_mobilenet_v3_large_fpn(
 model_fasterrcnn_mobilenet_v3_large_320_fpn(
   pretrained = FALSE,
   progress = TRUE,
-  num_classes = 91,
+  num_classes = 90,
   score_thresh = 0.05,
   nms_thresh = 0.5,
   detections_per_img = 100,
@@ -53,7 +53,7 @@ model_fasterrcnn_mobilenet_v3_large_320_fpn(
 
 \item{progress}{Logical. Show progress bar during download (unused).}
 
-\item{num_classes}{Number of output classes (default: 91 for COCO).}
+\item{num_classes}{Number of output classes excluding background (default: 90 for COCO).}
 
 \item{score_thresh}{Numeric. Minimum score threshold for detections (default: 0.05).}
 
@@ -118,21 +118,6 @@ input <- image  \%>\%
   transform_normalize(norm_mean, norm_std)
 batch_normalized <- input$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
 
-# ResNet-50 FPN
-model <- model_fasterrcnn_resnet50_fpn(pretrained = TRUE, score_thresh = 0.5,
-                                        nms_thresh = 0.8, detections_per_img = 3)
-model$eval()
-torch::with_no_grad({pred <- model(batch_normalized)$detections[[1]]})
-
-num_boxes <- as.integer(pred$boxes$size()[1])
-keep <- seq_len(min(5, num_boxes))
-boxes <- pred$boxes[keep, ]$view(c(-1, 4))
-labels <- coco_classes(as.integer(pred$labels[keep]))
-if (num_boxes > 0) {
-  boxed <- draw_bounding_boxes(image, boxes, labels = labels)
-  tensor_image_browse(boxed)
-}
-
 # ResNet-50 FPN V2
 model <- model_fasterrcnn_resnet50_fpn_v2(pretrained = TRUE)
 model$eval()
@@ -146,26 +131,8 @@ if (num_boxes > 0) {
   tensor_image_browse(boxed)
 }
 
-# MobileNet V3 Large FPN
-batch <- image$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
-
-model <- model_fasterrcnn_mobilenet_v3_large_fpn(
-  pretrained = TRUE, score_thresh = 0.02, nms_thresh = 0.9, detections_per_img = 5
-)
-model$eval()
-torch::with_no_grad({
-  pred <- model(batch)$detections[[1]]
-})
-num_boxes <- as.integer(pred$boxes$size()[1])
-keep <- seq_len(min(5, num_boxes))
-boxes <- pred$boxes[keep, ]$view(c(-1, 4))
-labels <- coco_classes(as.integer(pred$labels[keep]))
-if (num_boxes > 0) {
-  boxed <- draw_bounding_boxes(image, boxes, labels = labels)
-  tensor_image_browse(boxed)
-}
-
 # MobileNet V3 Large 320 FPN
+batch <- image$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
 model <- model_fasterrcnn_mobilenet_v3_large_320_fpn(
   pretrained = TRUE, score_thresh = 0.02, nms_thresh = 0.8, detections_per_img = 5
 )

--- a/man/model_fasterrcnn.Rd
+++ b/man/model_fasterrcnn.Rd
@@ -104,8 +104,8 @@ Input images should be \code{torch_tensor}s of shape
 \examples{
 \dontrun{
 library(magrittr)
-norm_mean <- c(0.485, 0.456, 0.406) # ImageNet normalization constants, see
-# https://pytorch.org/vision/stable/models.html
+# ImageNet normalization constants, see https://pytorch.org/vision/stable/models.html
+norm_mean <- c(0.485, 0.456, 0.406)
 norm_std  <- c(0.229, 0.224, 0.225)
 # Use a publicly available image of an animal
 url <- paste0("https://upload.wikimedia.org/wikipedia/commons/thumb/",
@@ -119,17 +119,15 @@ input <- image  \%>\%
 batch_normalized <- input$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
 
 # ResNet-50 FPN V2
-model <- model_fasterrcnn_resnet50_fpn_v2(pretrained = TRUE)
+model <- model_fasterrcnn_resnet50_fpn_v2(pretrained = TRUE, , detections_per_img = 5 )
 model$eval()
 torch::with_no_grad({pred <- model(batch_normalized)$detections[[1]]})
-num_boxes <- as.integer(pred$boxes$size()[1])
-keep <- seq_len(min(5, num_boxes))
-boxes <- pred$boxes[keep, ]$view(c(-1, 4))
-labels <- coco_classes(as.integer(pred$labels[keep]))
-if (num_boxes > 0) {
-  boxed <- draw_bounding_boxes(image, boxes, labels = labels)
-  tensor_image_browse(boxed)
-}
+labels <- coco_classes(as.integer(pred$labels))
+
+# Visualize boxes
+labels <- coco_classes(as.integer(pred$labels))
+boxed <- draw_bounding_boxes(image, pred$boxes, labels = labels)
+tensor_image_browse(boxed)
 
 # MobileNet V3 Large 320 FPN
 batch <- image$unsqueeze(1)    # Add batch dimension (1, 3, H, W)
@@ -138,14 +136,11 @@ model <- model_fasterrcnn_mobilenet_v3_large_320_fpn(
 )
 model$eval()
 torch::with_no_grad({pred <- model(batch)$detections[[1]]})
-num_boxes <- as.integer(pred$boxes$size()[1])
-keep <- seq_len(min(5, num_boxes))
-boxes <- pred$boxes[keep, ]$view(c(-1, 4))
-labels <- coco_classes(as.integer(pred$labels[keep]))
-if (num_boxes > 0) {
-  boxed <- draw_bounding_boxes(image, boxes, labels = labels)
-  tensor_image_browse(boxed)
-}
+
+# Visualize boxes
+labels <- coco_classes(as.integer(pred$labels))
+boxed <- draw_bounding_boxes(image, pred$boxes, labels = labels)
+tensor_image_browse(boxed)
 }
 
 }

--- a/man/model_maskrcnn.Rd
+++ b/man/model_maskrcnn.Rd
@@ -93,6 +93,7 @@ Returns a list with:
 \examples{
 \dontrun{
 library(magrittr)
+# ImageNet normalization constants, see https://pytorch.org/vision/stable/models.html
 norm_mean <- c(0.485, 0.456, 0.406)
 norm_std  <- c(0.229, 0.224, 0.225)
 
@@ -108,21 +109,15 @@ input <- img \%>\%
 batch <- input$unsqueeze(1)
 
 # Mask R-CNN ResNet-50 FPN
-model <- model_maskrcnn_resnet50_fpn(pretrained = TRUE)
+model <- model_maskrcnn_resnet50_fpn(pretrained = TRUE, , detections_per_img = 5)
 model$eval()
-pred <- model(batch)$detections
 
-# Access predictions
-boxes <- pred$boxes
-labels <- pred$labels
-scores <- pred$scores
-masks <- pred$masks  # Segmentation masks (N, 28, 28)
+torch::with_no_grad({pred <- model(batch)$detections[[1]]})
 
 # Visualize boxes
-if (boxes$size(1) > 0) {
-  boxed <- draw_bounding_boxes(input, boxes[1:5, ])
-  tensor_image_browse(boxed)
-}
+labels <- coco_classes(as.integer(pred$labels))
+boxed <- draw_bounding_boxes(image, pred$boxes, labels = labels)
+tensor_image_browse(boxed)
 }
 
 }

--- a/man/model_maskrcnn.Rd
+++ b/man/model_maskrcnn.Rd
@@ -9,7 +9,7 @@
 model_maskrcnn_resnet50_fpn(
   pretrained = FALSE,
   progress = TRUE,
-  num_classes = 91,
+  num_classes = 90,
   score_thresh = 0.05,
   nms_thresh = 0.5,
   detections_per_img = 100,
@@ -19,7 +19,7 @@ model_maskrcnn_resnet50_fpn(
 model_maskrcnn_resnet50_fpn_v2(
   pretrained = FALSE,
   progress = TRUE,
-  num_classes = 91,
+  num_classes = 90,
   score_thresh = 0.05,
   nms_thresh = 0.5,
   detections_per_img = 100,
@@ -31,7 +31,7 @@ model_maskrcnn_resnet50_fpn_v2(
 
 \item{progress}{Logical. Show progress bar during download (unused).}
 
-\item{num_classes}{Number of output classes (default: 91 for COCO).}
+\item{num_classes}{Number of output classes excluding background (default: 90 for COCO).}
 
 \item{score_thresh}{Numeric. Minimum score threshold for detections (default: 0.05).}
 

--- a/man/transform_perspective.Rd
+++ b/man/transform_perspective.Rd
@@ -26,7 +26,7 @@ image.}
 
 \item{interpolation}{(int, optional) Desired interpolation. An integer
 \code{0 = nearest}, \code{2 = bilinear}, and \code{3 = bicubic} or a name from
-\code{\link[magick:filter_types]{magick::filter_types()}}.}
+\code{\link[magick:options]{magick::filter_types()}}.}
 
 \item{fill}{(int or str or tuple): Pixel fill value for constant fill.
 Default is 0. If a tuple of length 3, it is used to fill R, G, B channels

--- a/man/transform_random_perspective.Rd
+++ b/man/transform_random_perspective.Rd
@@ -22,7 +22,7 @@ and ranges from 0 to 1. Default is 0.5.}
 
 \item{interpolation}{(int, optional) Desired interpolation. An integer
 \code{0 = nearest}, \code{2 = bilinear}, and \code{3 = bicubic} or a name from
-\code{\link[magick:filter_types]{magick::filter_types()}}.}
+\code{\link[magick:options]{magick::filter_types()}}.}
 
 \item{fill}{(int or str or tuple): Pixel fill value for constant fill.
 Default is 0. If a tuple of length 3, it is used to fill R, G, B channels

--- a/man/transform_random_resized_crop.Rd
+++ b/man/transform_random_resized_crop.Rd
@@ -28,7 +28,7 @@ ratio cropped.}
 
 \item{interpolation}{(int, optional) Desired interpolation. An integer
 \code{0 = nearest}, \code{2 = bilinear}, and \code{3 = bicubic} or a name from
-\code{\link[magick:filter_types]{magick::filter_types()}}.}
+\code{\link[magick:options]{magick::filter_types()}}.}
 }
 \description{
 Crop the given image to a random size and aspect ratio. The image can be a

--- a/man/transform_resize.Rd
+++ b/man/transform_resize.Rd
@@ -17,7 +17,7 @@ i.e, if height > width, then image will be rescaled to
 
 \item{interpolation}{(int, optional) Desired interpolation. An integer
 \code{0 = nearest}, \code{2 = bilinear}, and \code{3 = bicubic} or a name from
-\code{\link[magick:filter_types]{magick::filter_types()}}.}
+\code{\link[magick:options]{magick::filter_types()}}.}
 }
 \description{
 The image can be a Magic Image or a torch Tensor, in which case it is

--- a/man/transform_resized_crop.Rd
+++ b/man/transform_resized_crop.Rd
@@ -26,7 +26,7 @@ i.e, if height > width, then image will be rescaled to
 
 \item{interpolation}{(int, optional) Desired interpolation. An integer
 \code{0 = nearest}, \code{2 = bilinear}, and \code{3 = bicubic} or a name from
-\code{\link[magick:filter_types]{magick::filter_types()}}.}
+\code{\link[magick:options]{magick::filter_types()}}.}
 }
 \description{
 Crop an image and resize it to a desired size

--- a/tests/testthat/test-models-faster_rcnn.R
+++ b/tests/testthat/test-models-faster_rcnn.R
@@ -110,7 +110,7 @@ test_that("tests for pretrained model_fasterrcnn_resnet50_fpn", {
 
   input <- base_loader("assets/class/cat/cat.4.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(180,180)) %>%
-    transform_normalize(mean = c(0.485, 0.456, 0.406), std = c(0.229, 0.224, 0.225)) %<% torch_unsqueeze(1)
+    transform_normalize(mean = c(0.485, 0.456, 0.406), std = c(0.229, 0.224, 0.225)) %>% torch_unsqueeze(1)
   model <- model_fasterrcnn_resnet50_fpn(pretrained = TRUE, score_thresh = 0.35, nms_thresh = 0.9, detections_per_img = 10)
   model$eval()
   out <- model(input)
@@ -130,7 +130,7 @@ test_that("tests for pretrained model_fasterrcnn_resnet50_fpn_v2", {
 
   input <- base_loader("assets/class/cat/cat.4.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(180,180)) %>%
-    transform_normalize(mean = c(0.485, 0.456, 0.406), std = c(0.229, 0.224, 0.225)) %<% torch_unsqueeze(1)
+    transform_normalize(mean = c(0.485, 0.456, 0.406), std = c(0.229, 0.224, 0.225)) %>% torch_unsqueeze(1)
   model <- model_fasterrcnn_resnet50_fpn_v2(pretrained = TRUE, score_thresh = 0.4, nms_thresh = 0.9, detections_per_img = 10)
   model$eval()
   out <- model(input)
@@ -147,7 +147,7 @@ test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_fpn", {
   skip_if(Sys.getenv("TEST_LARGE_MODELS", unset = 0) != 1,
           "Skipping test: set TEST_LARGE_MODELS=1 to enable tests requiring large downloads.")
 
-  model <- model_fasterrcnn_mobilenet_v3_large_fpn(pretrained = TRUE, score_thresh = 0.02, nms_thresh = 0.9, detections_per_img = 10)
+  model <- model_fasterrcnn_mobilenet_v3_large_fpn(pretrained = TRUE, detections_per_img = 10)
   input <- base_loader("assets/class/dog/dog.0.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(240,240)) %>% torch_unsqueeze(1)
   out <- model(input)
@@ -164,7 +164,7 @@ test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_320_fpn", {
   skip_if(Sys.getenv("TEST_LARGE_MODELS", unset = 0) != 1,
           "Skipping test: set TEST_LARGE_MODELS=1 to enable tests requiring large downloads.")
 
-  model <- model_fasterrcnn_mobilenet_v3_large_320_fpn(pretrained = TRUE, score_thresh = 0.02, nms_thresh = 0.8, detections_per_img = 10)
+  model <- model_fasterrcnn_mobilenet_v3_large_320_fpn(pretrained = TRUE, detections_per_img = 10)
   input <- base_loader("assets/class/dog/dog.1.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(360,360)) %>% torch_unsqueeze(1)
   out <- model(input)

--- a/tests/testthat/test-models-faster_rcnn.R
+++ b/tests/testthat/test-models-faster_rcnn.R
@@ -119,11 +119,10 @@ test_that("tests for pretrained model_fasterrcnn_resnet50_fpn", {
   expect_tensor(out$detections[[1]]$labels)
   expect_tensor(out$detections[[1]]$scores)
   expect_tensor(out$detections[[1]]$boxes)
-  # Verify no background class (class 1) is returned
+  # Verify background class is removed, labels should be COCO IDs [1, 90]
   if (out$detections[[1]]$labels$shape[1] > 0) {
     labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
-    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
-    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(all(labels_vec >= 1 & labels_vec <= 90), info = "All labels are in range [1, 90]")
     expect_true(any(labels_vec == 17), info = "model found a cat")
   }
   # we cannot succesfully assert bbox here :
@@ -147,10 +146,9 @@ test_that("tests for pretrained model_fasterrcnn_resnet50_fpn_v2", {
   expect_tensor(out$detections[[1]]$scores)
   if (out$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(out$detections[[1]]$boxes, 180, 180)
-    # Verify no background class (class 1) is returned
+    # Verify background class is removed, labels should be COCO IDs [1, 90]
     labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
-    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
-    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(all(labels_vec >= 1 & labels_vec <= 90), info = "All labels are in range [1, 90]")
     expect_true(any(labels_vec == 17), info = "model found a cat")  }
 })
 
@@ -168,10 +166,9 @@ test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_fpn", {
   expect_tensor(out$detections[[1]]$scores)
   if (out$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(out$detections[[1]]$boxes, 240, 240)
-    # Verify no background class (class 1) is returned
+    # Verify background class is removed, labels should be COCO IDs [1, 90]
     labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
-    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
-    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(all(labels_vec >= 1 & labels_vec <= 90), info = "All labels are in range [1, 90]")
     expect_true(any(labels_vec == 18), info = "model found a dog")  }
 })
 
@@ -189,10 +186,9 @@ test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_320_fpn", {
   expect_tensor(out$detections[[1]]$scores)
   if (out$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(out$detections[[1]]$boxes, 360, 360)
-    # Verify no background class (class 1) is returned
+    # Verify background class is removed, labels should be COCO IDs [1, 90]
     labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
-    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
-    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(all(labels_vec >= 1 & labels_vec <= 90), info = "All labels are in range [1, 90]")
     expect_true(any(labels_vec == 18), info = "model found a dog")  }
 })
 

--- a/tests/testthat/test-models-faster_rcnn.R
+++ b/tests/testthat/test-models-faster_rcnn.R
@@ -119,6 +119,13 @@ test_that("tests for pretrained model_fasterrcnn_resnet50_fpn", {
   expect_tensor(out$detections[[1]]$labels)
   expect_tensor(out$detections[[1]]$scores)
   expect_tensor(out$detections[[1]]$boxes)
+  # Verify no background class (class 1) is returned
+  if (out$detections[[1]]$labels$shape[1] > 0) {
+    labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
+    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
+    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(any(labels_vec == 17), info = "model found a cat")
+  }
   # we cannot succesfully assert bbox here :
   #   expect_bbox_is_xyxy(out$detections[[1]]$boxes, 180, 180)
   #
@@ -140,7 +147,11 @@ test_that("tests for pretrained model_fasterrcnn_resnet50_fpn_v2", {
   expect_tensor(out$detections[[1]]$scores)
   if (out$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(out$detections[[1]]$boxes, 180, 180)
-  }
+    # Verify no background class (class 1) is returned
+    labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
+    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
+    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(any(labels_vec == 17), info = "model found a cat")  }
 })
 
 test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_fpn", {
@@ -157,7 +168,11 @@ test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_fpn", {
   expect_tensor(out$detections[[1]]$scores)
   if (out$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(out$detections[[1]]$boxes, 240, 240)
-  }
+    # Verify no background class (class 1) is returned
+    labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
+    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
+    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(any(labels_vec == 18), info = "model found a dog")  }
 })
 
 test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_320_fpn", {
@@ -174,6 +189,10 @@ test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_320_fpn", {
   expect_tensor(out$detections[[1]]$scores)
   if (out$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(out$detections[[1]]$boxes, 360, 360)
-  }
+    # Verify no background class (class 1) is returned
+    labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
+    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
+    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(any(labels_vec == 18), info = "model found a dog")  }
 })
 

--- a/tests/testthat/test-models-faster_rcnn.R
+++ b/tests/testthat/test-models-faster_rcnn.R
@@ -4,7 +4,7 @@ test_that("tests for non-pretrained model_fasterrcnn_resnet50_fpn", {
   input <- base_loader("assets/class/cat/cat.0.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(200,200)) %>% torch_unsqueeze(1)
   model$eval()
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_is(out$detections, "list")
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
@@ -15,7 +15,7 @@ test_that("tests for non-pretrained model_fasterrcnn_resnet50_fpn", {
 
 
   model <- model_fasterrcnn_resnet50_fpn(num_classes = 10, score_thresh = 0.5, nms_thresh = 0.8, detections_per_img = 3)
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$boxes)
@@ -32,7 +32,7 @@ test_that("tests for non-pretrained model_fasterrcnn_resnet50_fpn_v2", {
   input <- base_loader("assets/class/cat/cat.1.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(180,180)) %>% torch_unsqueeze(1)
   model$eval()
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$boxes)
@@ -42,7 +42,7 @@ test_that("tests for non-pretrained model_fasterrcnn_resnet50_fpn_v2", {
 
 
   model <- model_fasterrcnn_resnet50_fpn_v2(num_classes = 10, score_thresh = 0.5, nms_thresh = 0.8, detections_per_img = 3)
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$boxes)
@@ -59,7 +59,7 @@ test_that("tests for non-pretrained model_fasterrcnn_mobilenet_v3_large_fpn", {
   input <- base_loader("assets/class/cat/cat.2.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(180,180)) %>% torch_unsqueeze(1)
   model$eval()
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$boxes)
@@ -69,7 +69,7 @@ test_that("tests for non-pretrained model_fasterrcnn_mobilenet_v3_large_fpn", {
 
 
   model <- model_fasterrcnn_resnet50_fpn_v2(num_classes = 10, score_thresh = 0.5, nms_thresh = 0.8, detections_per_img = 3)
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$boxes)
@@ -86,7 +86,7 @@ test_that("tests for non-pretrained model_fasterrcnn_mobilenet_v3_large_320_fpn"
   input <- base_loader("assets/class/cat/cat.3.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(180,180)) %>% torch_unsqueeze(1)
   model$eval()
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$boxes)
@@ -95,7 +95,7 @@ test_that("tests for non-pretrained model_fasterrcnn_mobilenet_v3_large_320_fpn"
   expect_equal(out$detections[[1]]$boxes$shape[2], 4L)
 
   model <- model_fasterrcnn_mobilenet_v3_large_320_fpn(num_classes = 10, score_thresh = 0.5, nms_thresh = 0.8, detections_per_img = 3)
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$boxes)
@@ -113,7 +113,7 @@ test_that("tests for pretrained model_fasterrcnn_resnet50_fpn", {
     transform_normalize(mean = c(0.485, 0.456, 0.406), std = c(0.229, 0.224, 0.225)) %>% torch_unsqueeze(1)
   model <- model_fasterrcnn_resnet50_fpn(pretrained = TRUE, score_thresh = 0.35, nms_thresh = 0.9, detections_per_img = 10)
   model$eval()
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$labels)
@@ -139,7 +139,7 @@ test_that("tests for pretrained model_fasterrcnn_resnet50_fpn_v2", {
     transform_normalize(mean = c(0.485, 0.456, 0.406), std = c(0.229, 0.224, 0.225)) %>% torch_unsqueeze(1)
   model <- model_fasterrcnn_resnet50_fpn_v2(pretrained = TRUE, score_thresh = 0.4, nms_thresh = 0.9, detections_per_img = 10)
   model$eval()
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$labels)
@@ -159,7 +159,7 @@ test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_fpn", {
   model <- model_fasterrcnn_mobilenet_v3_large_fpn(pretrained = TRUE, detections_per_img = 10)
   input <- base_loader("assets/class/dog/dog.0.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(240,240)) %>% torch_unsqueeze(1)
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$labels)
@@ -179,7 +179,7 @@ test_that("tests for pretrained model_fasterrcnn_mobilenet_v3_large_320_fpn", {
   model <- model_fasterrcnn_mobilenet_v3_large_320_fpn(pretrained = TRUE, detections_per_img = 10)
   input <- base_loader("assets/class/dog/dog.1.jpg") %>%
     transform_to_tensor() %>% transform_resize(c(360,360)) %>% torch_unsqueeze(1)
-  out <- model(input)
+  torch::with_no_grad({out <- model(input)})
   expect_named(out, c("features","detections"))
   expect_named(out$detections[[1]], c("boxes","labels", "scores"))
   expect_tensor(out$detections[[1]]$labels)

--- a/tests/testthat/test-models-mask_rcnn.R
+++ b/tests/testthat/test-models-mask_rcnn.R
@@ -172,6 +172,14 @@ test_that("mask_rcnn pretrained infer correctly", {
   # Masks should be expanded back to image size
   if (output$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(output$detections[[1]]$boxes, 200, 200)
+    # Verify no background class (class 1) is returned
+    labels_vec <- as.integer(output$detections[[1]]$labels$cpu())
+    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
+    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(any(labels_vec == 17), info = "model found a cat")
+    # Verify masks match number of detections
+    expect_equal(output$detections[[1]]$masks$shape[1], length(labels_vec),
+                 info = "Number of masks should match number of detections")
   }
 
 })
@@ -187,6 +195,14 @@ test_that("mask_rcnn_v2 pretrained infer correctly", {
   # Masks should be expanded back to image size
   if (output$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(output$detections[[1]]$boxes, 200, 200)
+    # Verify no background class (class 1) is returned
+    labels_vec <- as.integer(output$detections[[1]]$labels$cpu())
+    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
+    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(any(labels_vec == 17), info = "model found a cat")
+    # Verify masks match number of detections
+    expect_equal(output$detections[[1]]$masks$shape[1], length(labels_vec),
+                 info = "Number of masks should match number of detections")
   }
 
 })

--- a/tests/testthat/test-models-mask_rcnn.R
+++ b/tests/testthat/test-models-mask_rcnn.R
@@ -150,14 +150,14 @@ test_that("maskrcnn with different num_classes works", {
   expect_tensor(output$detections[[1]]$masks)
 })
 
-test_that("maskrcnn pretrained requires num_classes = 91", {
+test_that("maskrcnn pretrained requires num_classes = 90", {
   skip_on_cran()
   skip_if_not(torch::torch_is_installed())
 
   # Should error when pretrained=TRUE with num_classes != 91
   expect_error(
     model_maskrcnn_resnet50_fpn(pretrained = TRUE, num_classes = 10, score_thresh = 0.6, nms_thresh = 0.9, detections_per_img = 100),
-    "Pretrained weights require num_classes = 91"
+    "Pretrained weights require num_classes = 90"
   )
 })
 
@@ -175,7 +175,7 @@ test_that("mask_rcnn pretrained infer correctly", {
     # Verify no background class (class 1) is returned
     labels_vec <- as.integer(output$detections[[1]]$labels$cpu())
     expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
-    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(all(labels_vec >= 1 & labels_vec <= 90), info = "All labels are in range [1, 90]")
     expect_true(any(labels_vec == 17), info = "model found a cat")
     # Verify masks match number of detections
     expect_equal(output$detections[[1]]$masks$shape[1], length(labels_vec),
@@ -198,7 +198,7 @@ test_that("mask_rcnn_v2 pretrained infer correctly", {
     # Verify no background class (class 1) is returned
     labels_vec <- as.integer(output$detections[[1]]$labels$cpu())
     expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
-    expect_true(all(labels_vec >= 2 & labels_vec <= 91), info = "All labels are in range [2, 91]")
+    expect_true(all(labels_vec >= 1 & labels_vec <= 90), info = "All labels are in range [1, 90]")
     expect_true(any(labels_vec == 17), info = "model found a cat")
     # Verify masks match number of detections
     expect_equal(output$detections[[1]]$masks$shape[1], length(labels_vec),

--- a/tests/testthat/test-models-mask_rcnn.R
+++ b/tests/testthat/test-models-mask_rcnn.R
@@ -9,7 +9,7 @@ test_that("maskrcnn_resnet50_fpn loads without pretrained weights", {
   skip_on_cran()
   skip_if_not(torch::torch_is_installed())
 
-  model <- model_maskrcnn_resnet50_fpn(pretrained = FALSE, num_classes = 91)
+  model <- model_maskrcnn_resnet50_fpn(pretrained = FALSE, num_classes = 90)
   expect_s3_class(model, "nn_module")
   expect_true(!is.null(model$backbone))
   expect_true(!is.null(model$rpn))
@@ -172,9 +172,8 @@ test_that("mask_rcnn pretrained infer correctly", {
   # Masks should be expanded back to image size
   if (output$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(output$detections[[1]]$boxes, 200, 200)
-    # Verify no background class (class 1) is returned
+    # Verify background class is removed, labels should be COCO IDs [1, 90]
     labels_vec <- as.integer(output$detections[[1]]$labels$cpu())
-    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
     expect_true(all(labels_vec >= 1 & labels_vec <= 90), info = "All labels are in range [1, 90]")
     expect_true(any(labels_vec == 17), info = "model found a cat")
     # Verify masks match number of detections
@@ -195,9 +194,8 @@ test_that("mask_rcnn_v2 pretrained infer correctly", {
   # Masks should be expanded back to image size
   if (output$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(output$detections[[1]]$boxes, 200, 200)
-    # Verify no background class (class 1) is returned
+    # Verify background class is removed, labels should be COCO IDs [1, 90]
     labels_vec <- as.integer(output$detections[[1]]$labels$cpu())
-    expect_false(any(labels_vec == 1), info = "Background class (1) is not in detections")
     expect_true(all(labels_vec >= 1 & labels_vec <= 90), info = "All labels are in range [1, 90]")
     expect_true(any(labels_vec == 17), info = "model found a cat")
     # Verify masks match number of detections
@@ -212,14 +210,14 @@ test_that("mask_head_module initializes correctly", {
   skip_if_not(torch::torch_is_installed())
 
   mask_head <- mask_head_module()
-  mask_rcnn_pred <- mask_rcnn_predictor(num_classes = 91)
+  mask_rcnn_pred <- mask_rcnn_predictor(num_classes = 90)
   expect_is(mask_head, "nn_module")
 
   # Test forward pass
   input <- torch::torch_randn(2, 256, 14, 14)
   output <- input %>% mask_head() %>% mask_rcnn_pred()
 
-  # Output should be (2, 91, 28, 28)
+  # Output should be (2, 91, 28, 28) - 90 classes + 1 background
   expect_tensor_shape(output, c(2, 91, 28, 28))
 })
 
@@ -227,14 +225,14 @@ test_that("mask_head_module_v2 initializes correctly", {
   skip_on_cran()
   skip_if_not(torch::torch_is_installed())
 
-  mask_head <- mask_head_module_v2(num_classes = 91)
+  mask_head <- mask_head_module_v2(num_classes = 90)
   expect_s3_class(mask_head, "nn_module")
 
   # Test forward pass
   input <- torch::torch_randn(2, 256, 14, 14)
   output <- mask_head(input)
 
-  # Output should be (2, 91, 28, 28)
+  # Output should be (2, 91, 28, 28) - 90 classes + 1 background
   expect_tensor_shape(output, c(2, 91, 28, 28))
 })
 

--- a/tests/testthat/test-models-mask_rcnn.R
+++ b/tests/testthat/test-models-mask_rcnn.R
@@ -34,11 +34,11 @@ test_that("maskrcnn_resnet50_fpn inference works", {
   skip_if_not(torch::torch_is_installed())
 
   # We expect 0 detection here, we keep the compute budget for pretrained model
-  model <- model_maskrcnn_resnet50_fpn(pretrained = FALSE, num_classes = 91, score_thresh = 0.6, nms_thresh = 0.1, detections_per_img = 100)
+  model <- model_maskrcnn_resnet50_fpn(pretrained = FALSE, num_classes = 91, score_thresh = 0.6, nms_thresh = 0.1, detections_per_img = 10)
   model$eval()
 
   # Test forward pass
-  output <- model(input)
+  torch::with_no_grad({output <- model(input)})
 
   # Check output structure
   expect_named(output, c("features" ,"detections"))
@@ -70,11 +70,11 @@ test_that("maskrcnn_resnet50_fpn_v2 inference works", {
 
 
   # We expect 0 detection here, we keep the compute budget for pretrained model
-  model <- model_maskrcnn_resnet50_fpn_v2(pretrained = FALSE, num_classes = 91, score_thresh = 0.6, nms_thresh = 0.9, detections_per_img = 100)
+  model <- model_maskrcnn_resnet50_fpn_v2(pretrained = FALSE, num_classes = 91, score_thresh = 0.6, nms_thresh = 0.9, detections_per_img = 10)
   model$eval()
 
   # Test forward pass
-  output <- model(input)
+  torch::with_no_grad({output <- model(input)})
 
   # Check output structure
   expect_named(output, c("features" ,"detections"))
@@ -98,11 +98,11 @@ test_that("maskrcnn handles empty detections correctly", {
   model <- model_maskrcnn_resnet50_fpn(
     pretrained = FALSE,
     num_classes = 91,
-    score_thresh = 0.99, nms_thresh = 0.9, detections_per_img = 100
+    score_thresh = 0.99, nms_thresh = 0.9, detections_per_img = 10
   )
   model$eval()
 
-  output <- model(input)
+  torch::with_no_grad({output <- model(input)})
 
   # Should return empty tensors with correct shapes
   expect_tensor_shape(output$detections[[1]]$boxes, c(0,4))
@@ -144,7 +144,7 @@ test_that("maskrcnn with different num_classes works", {
   model$eval()
 
   input <- torch::torch_randn(1, 3, 800, 800)
-  output <- model(input)
+  torch::with_no_grad({output <- model(input)})
 
   # Should work without errors
   expect_tensor(output$detections[[1]]$masks)
@@ -165,10 +165,10 @@ test_that("mask_rcnn pretrained infer correctly", {
   skip_on_cran()
   skip_if_not(torch::torch_is_installed())
 
-  model <- model_maskrcnn_resnet50_fpn(pretrained = TRUE, score_thresh = 0.01, nms_thresh = 0.7, detections_per_img = 100)
+  model <- model_maskrcnn_resnet50_fpn(pretrained = TRUE, score_thresh = 0.5, nms_thresh = 0.7, detections_per_img = 10)
   model$eval()
 
-  output <- model(input)
+  torch::with_no_grad({output <- model(input)})
   # Masks should be expanded back to image size
   if (output$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(output$detections[[1]]$boxes, 200, 200)
@@ -187,10 +187,10 @@ test_that("mask_rcnn_v2 pretrained infer correctly", {
   skip_on_cran()
   skip_if_not(torch::torch_is_installed())
 
-  model <- model_maskrcnn_resnet50_fpn_v2(pretrained = TRUE, score_thresh = 0.01, nms_thresh = 0.7, detections_per_img = 100)
+  model <- model_maskrcnn_resnet50_fpn_v2(pretrained = TRUE, score_thresh = 0.5, nms_thresh = 0.7, detections_per_img = 10)
   model$eval()
 
-  output <- model(input)
+  torch::with_no_grad({output <- model(input)})
   # Masks should be expanded back to image size
   if (output$detections[[1]]$boxes$shape[1] > 0) {
     expect_bbox_is_xyxy(output$detections[[1]]$boxes, 200, 200)


### PR DESCRIPTION
- Update `coco_classes()` to the sparse 90 classes list to match model predictions.
- fix RPN Head and Box head architecure for `model_mask_rcnn_*`
- fix Level Anchor generator and mask decoding, and gather post-process detection into a function for `model_faster_rcnn_*`
- ensure accelerator compatibility to `model_faster_rcnn_*`
- include the expected class in pretrained model inference tests

Fix #316 