### PR TITLE
Use torchvisionlib ops_nms when available for model_fasterrcnn and model_maskrcnn

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # torchvision (development version)
 
+## Bug fixes and improvements
+
+* `nms()` now uses `torchvisionlib::ops_nms()` when torchvisionlib is installed, speeding up inference for `model_fasterrcnn_*()` and `model_maskrcnn_*()` (#321, #322).
+
 # torchvision 0.9.0
 
 ## Breaking changes

--- a/R/ops-boxes.R
+++ b/R/ops-boxes.R
@@ -18,20 +18,26 @@
 #'    not guaranteed to be the same between CPU and GPU. This is similar
 #'    to the behavior of argsort in torch when repeated values are present.
 #'
-#'    When the optional `torchvisionlib` package is installed, `nms()` uses
-#'    `torchvisionlib::ops_nms()` for faster inference. Otherwise, it falls
-#'    back to the pure R algorithm below.
+#'    When the optional `torchvisionlib` package and its native library are
+#'    installed, `nms()` uses `torchvisionlib::ops_nms()` for faster inference.
+#'    Otherwise, it falls back to the pure R algorithm below.
 #'
 #' @return keep (Tensor): int64 tensor with the indices of the elements that
 #'  have been kept by NMS, sorted in decreasing order of scores.
 #'
 #' @export
 nms <- function(boxes, scores, iou_threshold) {
-  if (rlang::is_installed("torchvisionlib")) {
+  if (.torchvisionlib_nms_available()) {
     return(torchvisionlib::ops_nms(boxes, scores, iou_threshold))
   }
 
   .nms_r(boxes, scores, iou_threshold)
+}
+
+#' @noRd
+.torchvisionlib_nms_available <- function() {
+  rlang::is_installed("torchvisionlib") &&
+    isTRUE(torchvisionlib::torchvisionlib_is_installed())
 }
 
 #' @noRd

--- a/R/ops-boxes.R
+++ b/R/ops-boxes.R
@@ -27,7 +27,7 @@
 #'
 #' @export
 nms <- function(boxes, scores, iou_threshold) {
-  if (.torchvisionlib_nms_available()) {
+  if (.torchvisionlib_is_available()) {
     return(torchvisionlib::ops_nms(boxes, scores, iou_threshold))
   }
 
@@ -35,7 +35,7 @@ nms <- function(boxes, scores, iou_threshold) {
 }
 
 #' @noRd
-.torchvisionlib_nms_available <- function() {
+.torchvisionlib_is_available <- function() {
   rlang::is_installed("torchvisionlib") &&
     isTRUE(torchvisionlib::torchvisionlib_is_installed())
 }

--- a/R/ops-boxes.R
+++ b/R/ops-boxes.R
@@ -18,15 +18,24 @@
 #'    not guaranteed to be the same between CPU and GPU. This is similar
 #'    to the behavior of argsort in torch when repeated values are present.
 #'
-#'    Current algorithm has a time complexity of O(n^2) and runs in native R.
-#'    It may be improve in the future by a Rcpp implementation or through alternative algorithm
+#'    When the optional `torchvisionlib` package is installed, `nms()` uses
+#'    `torchvisionlib::ops_nms()` for faster inference. Otherwise, it falls
+#'    back to the pure R algorithm below.
 #'
 #' @return keep (Tensor): int64 tensor with the indices of the elements that
 #'  have been kept by NMS, sorted in decreasing order of scores.
 #'
 #' @export
 nms <- function(boxes, scores, iou_threshold) {
+  if (rlang::is_installed("torchvisionlib")) {
+    return(torchvisionlib::ops_nms(boxes, scores, iou_threshold))
+  }
 
+  .nms_r(boxes, scores, iou_threshold)
+}
+
+#' @noRd
+.nms_r <- function(boxes, scores, iou_threshold) {
   # Handle empty inputs gracefully
 
   n_boxes <- boxes$shape[1]

--- a/man/nms.Rd
+++ b/man/nms.Rd
@@ -34,7 +34,7 @@ criterion with respect to a reference box, the selected box is
 not guaranteed to be the same between CPU and GPU. This is similar
 to the behavior of argsort in torch when repeated values are present.
 
-When the optional \pkg{torchvisionlib} package is installed, \code{nms()}
-uses \code{torchvisionlib::ops_nms()} for faster inference. Otherwise, it
-falls back to the pure R algorithm.
+When the optional \pkg{torchvisionlib} package and its native library are
+installed, \code{nms()} uses \code{torchvisionlib::ops_nms()} for faster inference.
+Otherwise, it falls back to the pure R algorithm.
 }

--- a/man/nms.Rd
+++ b/man/nms.Rd
@@ -34,6 +34,7 @@ criterion with respect to a reference box, the selected box is
 not guaranteed to be the same between CPU and GPU. This is similar
 to the behavior of argsort in torch when repeated values are present.
 
-Current algorithm has a time complexity of O(n^2) and runs in native R.
-It may be improve in the future by a Rcpp implementation or through alternative algorithm
+When the optional \pkg{torchvisionlib} package is installed, \code{nms()}
+uses \code{torchvisionlib::ops_nms()} for faster inference. Otherwise, it
+falls back to the pure R algorithm.
 }

--- a/tests/testthat/test-ops-boxes.R
+++ b/tests/testthat/test-ops-boxes.R
@@ -67,3 +67,42 @@ test_that("box_iou", {
   expect_equal_to_r(x, matrix(1, nrow = 5, ncol = 5))
 })
 
+test_that("nms matches the pure R implementation", {
+  boxes_nms <- torch::torch_tensor(
+    matrix(
+      c(
+        0, 0, 2, 2,
+        0.1, 0.1, 2.1, 2.1,
+        5, 5, 6, 6
+      ),
+      ncol = 4,
+      byrow = TRUE
+    )
+  )
+  scores_nms <- torch::torch_tensor(c(0.9, 0.8, 0.7))
+
+  expected <- .nms_r(boxes_nms, scores_nms, 0.5)
+  expect_equal_to_r(nms(boxes_nms, scores_nms, 0.5), as.integer(expected$cpu()))
+})
+
+test_that("nms uses torchvisionlib when installed", {
+  skip_if_not(rlang::is_installed("torchvisionlib"))
+
+  boxes_nms <- torch::torch_tensor(
+    matrix(
+      c(
+        0, 0, 2, 2,
+        0.1, 0.1, 2.1, 2.1,
+        5, 5, 6, 6
+      ),
+      ncol = 4,
+      byrow = TRUE
+    )
+  )
+  scores_nms <- torch::torch_tensor(c(0.9, 0.8, 0.7))
+
+  expect_equal_to_r(
+    nms(boxes_nms, scores_nms, 0.5),
+    as.integer(torchvisionlib::ops_nms(boxes_nms, scores_nms, 0.5)$cpu())
+  )
+})

--- a/tests/testthat/test-ops-boxes.R
+++ b/tests/testthat/test-ops-boxes.R
@@ -67,26 +67,8 @@ test_that("box_iou", {
   expect_equal_to_r(x, matrix(1, nrow = 5, ncol = 5))
 })
 
-test_that("nms matches the pure R implementation", {
-  boxes_nms <- torch::torch_tensor(
-    matrix(
-      c(
-        0, 0, 2, 2,
-        0.1, 0.1, 2.1, 2.1,
-        5, 5, 6, 6
-      ),
-      ncol = 4,
-      byrow = TRUE
-    )
-  )
-  scores_nms <- torch::torch_tensor(c(0.9, 0.8, 0.7))
-
-  expected <- .nms_r(boxes_nms, scores_nms, 0.5)
-  expect_equal_to_r(nms(boxes_nms, scores_nms, 0.5), as.integer(expected$cpu()))
-})
-
 test_that("nms uses torchvisionlib when installed", {
-  skip_if_not(.torchvisionlib_nms_available())
+  skip_if_not(.torchvisionlib_is_available())
 
   boxes_nms <- torch::torch_tensor(
     matrix(

--- a/tests/testthat/test-ops-boxes.R
+++ b/tests/testthat/test-ops-boxes.R
@@ -86,7 +86,7 @@ test_that("nms matches the pure R implementation", {
 })
 
 test_that("nms uses torchvisionlib when installed", {
-  skip_if_not(rlang::is_installed("torchvisionlib"))
+  skip_if_not(.torchvisionlib_nms_available())
 
   boxes_nms <- torch::torch_tensor(
     matrix(


### PR DESCRIPTION
Fixes #321 
Fixes #322 

**Changes:**
- Dispatch nms() to torchvisionlib::ops_nms() when available in torchvisionlib.
- Keep the pure R NMS implementation as the fallback.
- Add coverage for fallback and native NMS dispatch.

**What is the result of this pull-request on the actual end-to-end models it has an impact on ?**
Before this PR, all six models, the four FasterRCNN variants and the two MaskRCNN variants, were running NMS entirely in pure R on every inference call. On a 520×520 image on CPU, that means that model_fasterrcnn_mobilenet_v3_large_320_fpn was taking around 25 seconds per image, with NMS being the main bottleneck. model_maskrcnn_resnet50_fpn was even worse taking around 1.7 minutes per image.

After this PR, when torchvisionlib is installed, both models dispatch NMS to torchvisionlib::ops_nms() which is a native C++ implementation. The same FasterRCNN model now runs in about 2 seconds, and MaskRCNN drops to  about 25 seconds. So FasterRCNN went from being unusably slow for interactive use to being reasonably fast and MaskRCNN went from taking nearly two minutes per image to under half a minute. For users who do not have torchvisionlib installed, nothing changes, the pure R fallback kicks in and behaviour is identical to before.

<img width="1200" height="600" alt="bench_nms_violin" src="https://github.com/user-attachments/assets/b894daeb-f061-4805-b4e9-aa02c4357b56" />

Image represents- NMS performance: torchvisionlib::ops_nms vs pure-R fallback (n=500 boxes)



<img width="1500" height="600" alt="bench_fasterrcnn_nms_violin" src="https://github.com/user-attachments/assets/7f8c4673-eb3b-4da6-9afe-2a07d18d50fb" />
Image represents: NMS performance impact on model_fasterrcnn_ (#321)


<img width="1500" height="600" alt="bench_maskrcnn_nms_violin" src="https://github.com/user-attachments/assets/7b7a374d-f866-4daf-9f33-e1a2524f8278" />
Image represents: NMS performance impact on model_maskrcnn_ (#322)


