### PR TITLE
fix cifar download time leads to fail CMD CHECK

### DIFF
--- a/tests/testthat/helper-torchvision.R
+++ b/tests/testthat/helper-torchvision.R
@@ -63,3 +63,26 @@ expect_bbox_is_xyxy <- function(object, width, height) {
               info = "Each y_min must be smaller than its y_max.")
 
 }
+
+
+# The top detection on this cat image should be the cat class (COCO id 17).
+expect_coco_model_detects_cat <- function(model, min_score = 0.25) {
+  input <- base_loader("assets/class/cat/cat.2.jpg") %>%
+    transform_to_tensor() %>%
+    transform_resize(c(640, 640)) %>%
+    transform_normalize(mean = c(0.485, 0.456, 0.406), std = c(0.229, 0.224, 0.225)) %>%
+    torch::torch_unsqueeze(1)
+  model$eval()
+  torch::with_no_grad({
+    out <- model(input)
+  })
+  expect_named(out, "detections")
+  expect_named(out$detections[[1]], c("boxes", "labels", "scores"), ignore.order = TRUE)
+  expect_equal(out$detections[[1]]$boxes$shape[2], 4L)
+  labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
+  scores_vec <- as.numeric(out$detections[[1]]$scores$cpu())
+  expect_true(all(labels_vec >= 0 & labels_vec <= 90))
+  top <- which.max(scores_vec)
+  expect_equal(labels_vec[top], 17L)
+  expect_gt(scores_vec[top], min_score)
+}

--- a/tests/testthat/test-dataset-cifar.R
+++ b/tests/testthat/test-dataset-cifar.R
@@ -3,7 +3,8 @@ context("dataset-cifar")
 t <- withr::local_tempdir()
 
 test_that("cifar10", {
-
+  skip_if(Sys.getenv("TEST_LARGE_DATASETS", unset = 0) != 1,
+          "Skipping test: set TEST_LARGE_DATASETS=1 to enable tests requiring large downloads.")
   expect_error(
     ds <- cifar10_dataset(root = tempfile(), train = TRUE),
     class = "runtime_error"
@@ -27,7 +28,8 @@ test_that("cifar10", {
 })
 
 test_that("cifar100", {
-
+  skip_if(Sys.getenv("TEST_LARGE_DATASETS", unset = 0) != 1,
+          "Skipping test: set TEST_LARGE_DATASETS=1 to enable tests requiring large downloads.")
   expect_error(
     ds <- cifar100_dataset(root = tempfile(), train = TRUE),
     class = "runtime_error"

--- a/tests/testthat/test-dataset-cifar.R
+++ b/tests/testthat/test-dataset-cifar.R
@@ -10,7 +10,9 @@ test_that("cifar10", {
     class = "runtime_error"
   )
 
-  ds <- cifar10_dataset(root = t, train = TRUE, download = TRUE)
+  withr::with_options(list(timeout = 3600), {
+    ds <- cifar10_dataset(root = t, train = TRUE, download = TRUE)
+  })
   expect_length(ds, 50000)
   el <- ds[1]
   expect_equal(dim(el[[1]]), c(32, 32, 3))
@@ -18,7 +20,9 @@ test_that("cifar10", {
   expect_named(el, c("x", "y"))
   expect_equal(ds$classes[el[[2]]], "frog")
 
-  ds <- cifar10_dataset(root = t, train = FALSE, download = TRUE)
+  withr::with_options(list(timeout = 3600), {
+    ds <- cifar10_dataset(root = t, train = FALSE, download = TRUE)
+  })
   expect_length(ds, 10000)
   el <- ds[1]
   expect_equal(dim(el[[1]]), c(32, 32, 3))
@@ -35,7 +39,9 @@ test_that("cifar100", {
     class = "runtime_error"
   )
 
-  ds <- cifar100_dataset(root = t, train = TRUE, download = TRUE)
+  withr::with_options(list(timeout = 3600), {
+    ds <- cifar100_dataset(root = t, train = TRUE, download = TRUE)
+  })
   expect_length(ds, 50000)
   el <- ds[2500]
   expect_equal(dim(el[[1]]), c(32, 32, 3))
@@ -43,7 +49,9 @@ test_that("cifar100", {
   expect_named(el, c("x", "y"))
   expect_equal(ds$classes[el[[2]]], "motorcycle")
 
-  ds <- cifar100_dataset(root = t, train = FALSE, download = TRUE)
+  withr::with_options(list(timeout = 3600), {
+    ds <- cifar100_dataset(root = t, train = FALSE, download = TRUE)
+  })
   expect_length(ds, 10000)
   el <- ds[502]
   expect_equal(dim(el[[1]]), c(32, 32, 3))

--- a/tests/testthat/test-models-lw_detr.R
+++ b/tests/testthat/test-models-lw_detr.R
@@ -99,32 +99,10 @@ test_that("model_lw_detr pretrained weights require COCO num_classes", {
   expect_error(model_lw_detr_tiny(pretrained = TRUE, num_classes = 10), "num_classes = 91")
 })
 
-# The top detection on this cat image should be the cat class (COCO id 17).
-expect_lw_detr_detects_cat <- function(model) {
-  input <- base_loader("assets/class/cat/cat.2.jpg") %>%
-    transform_to_tensor() %>%
-    transform_resize(c(640, 640)) %>%
-    transform_normalize(mean = c(0.485, 0.456, 0.406), std = c(0.229, 0.224, 0.225)) %>%
-    torch_unsqueeze(1)
-  model$eval()
-  torch::with_no_grad({
-    out <- model(input)
-  })
-  expect_named(out, "detections")
-  expect_named(out$detections[[1]], c("boxes", "labels", "scores"))
-  expect_equal(out$detections[[1]]$boxes$shape[2], 4L)
-  labels_vec <- as.integer(out$detections[[1]]$labels$cpu())
-  scores_vec <- as.numeric(out$detections[[1]]$scores$cpu())
-  expect_true(all(labels_vec >= 0 & labels_vec <= 90))
-  top <- which.max(scores_vec)
-  expect_equal(labels_vec[top], 17L)
-  expect_gt(scores_vec[top], 0.25)
-}
-
 test_that("tests for pretrained model_lw_detr_tiny", {
   skip_on_cran()
   skip_if_not(torch::torch_is_installed())
-  expect_lw_detr_detects_cat(model_lw_detr_tiny(pretrained = TRUE))
+  expect_coco_model_detects_cat(model_lw_detr_tiny(pretrained = TRUE))
 })
 
 test_that("tests for pretrained model_lw_detr_small", {
@@ -134,7 +112,7 @@ test_that("tests for pretrained model_lw_detr_small", {
   )
   skip_on_cran()
   skip_if_not(torch::torch_is_installed())
-  expect_lw_detr_detects_cat(model_lw_detr_small(pretrained = TRUE))
+  expect_coco_model_detects_cat(model_lw_detr_small(pretrained = TRUE))
 })
 
 test_that("tests for pretrained model_lw_detr_medium", {
@@ -144,7 +122,7 @@ test_that("tests for pretrained model_lw_detr_medium", {
   )
   skip_on_cran()
   skip_if_not(torch::torch_is_installed())
-  expect_lw_detr_detects_cat(model_lw_detr_medium(pretrained = TRUE))
+  expect_coco_model_detects_cat(model_lw_detr_medium(pretrained = TRUE))
 })
 
 test_that("tests for pretrained model_lw_detr_large", {
@@ -154,5 +132,5 @@ test_that("tests for pretrained model_lw_detr_large", {
   )
   skip_on_cran()
   skip_if_not(torch::torch_is_installed())
-  expect_lw_detr_detects_cat(model_lw_detr_large(pretrained = TRUE))
+  expect_coco_model_detects_cat(model_lw_detr_large(pretrained = TRUE))
 })


### PR DESCRIPTION
- CIFAR now goes to LARGE_DATASET
- promote  `expect_coco_model_detects_cat()` to test helpers.