### PR TITLE
Fix: improve reliability of `lfw_dataset`

### DIFF
--- a/R/dataset-lfw.R
+++ b/R/dataset-lfw.R
@@ -78,10 +78,10 @@ lfw_people_dataset <- torch::dataset(
     "original" = "170 MB",
     "funneled" = "230 MB"
   ),
-  base_url = "https://ndownloader.figshare.com/files/",
+  base_url = "https://huggingface.co/datasets/DerrickUnleashed/LFW/resolve/main/",
   resources = list(
-    original = c("5976018", "a17d05bd522c52d84eca14327a23d494"),
-    funneled = c("5976015", "1b42dfed7d15c9b2dd63d5e5840c86ad")
+    original = c("lfw.tgz", "a17d05bd522c52d84eca14327a23d494"),
+    funneled = c("lfwfunneled.tgz", "1b42dfed7d15c9b2dd63d5e5840c86ad")
   ),
 
   initialize = function(
@@ -208,13 +208,13 @@ lfw_pairs_dataset <- torch::dataset(
     "original" = "170 MB",
     "funneled" = "230 MB"
   ),
-  base_url = "https://ndownloader.figshare.com/files/",
+  base_url = "https://huggingface.co/datasets/DerrickUnleashed/LFW/resolve/main/",
   resources = list(
-    original = c("5976018", "a17d05bd522c52d84eca14327a23d494"),
-    funneled = c("5976015", "1b42dfed7d15c9b2dd63d5e5840c86ad"),
-    pairsDevTrain.txt = c("5976012", "4f27cbf15b2da4a85c1907eb4181ad21"),
-    pairsDevTest.txt = c("5976009", "5132f7440eb68cf58910c8a45a2ac10b"),
-    pairs.txt = c("5976006", "9f1ba174e4e1c508ff7cdf10ac338a7d")
+    original = c("lfw.tgz", "a17d05bd522c52d84eca14327a23d494"),
+    funneled = c("lfwfunneled.tgz", "1b42dfed7d15c9b2dd63d5e5840c86ad"),
+    pairsDevTrain.txt = c("pairsDevTrain.txt", "4f27cbf15b2da4a85c1907eb4181ad21"),
+    pairsDevTest.txt = c("pairsDevTest.txt", "5132f7440eb68cf58910c8a45a2ac10b"),
+    pairs.txt = c("pairs.txt", "9f1ba174e4e1c508ff7cdf10ac338a7d")
   ),
 
   initialize = function(

--- a/tests/testthat/test-dataset-lfw.R
+++ b/tests/testthat/test-dataset-lfw.R
@@ -3,10 +3,7 @@ context("dataset-lfw")
 t <- withr::local_tempdir()
 
 test_that("tests for the LFW People dataset for original image_set", {
-  # MacOS / Windows runner fails with `cannot open URL 'https://ndownloader.figshare.com/files/5976015'` or `timeout`
-  skip_on_os("mac")
-  skip_on_os("windows")
-  skip_on_os("linux")
+
   lfw <- lfw_people_dataset(root = t, download = TRUE, split = "original")
   expect_length(lfw, 13233)
   first_item <- lfw[1]
@@ -18,10 +15,7 @@ test_that("tests for the LFW People dataset for original image_set", {
 })
 
 test_that("tests for the LFW People dataset for funneled image_set", {
-  # MacOS / Windows runner fails with `cannot open URL 'https://ndownloader.figshare.com/files/5976015'` or `timeout`
-  skip_on_os("mac")
-  skip_on_os("windows")
-  skip_on_os("linux")
+
   lfw <- lfw_people_dataset(root = t, download = TRUE, split = "funneled" )
   expect_length(lfw, 13233)
   first_item <- lfw[1]
@@ -33,10 +27,7 @@ test_that("tests for the LFW People dataset for funneled image_set", {
 })
 
 test_that("tests for the LFW People dataset for dataloader", {
-  # MacOS / Windows runner fails with `cannot open URL 'https://ndownloader.figshare.com/files/5976015'` or `timeout`
-  skip_on_os("mac")
-  skip_on_os("windows")
-  skip_on_os("linux")
+
   lfw <- lfw_people_dataset(root = t, transform = transform_to_tensor)
   dl <- dataloader(lfw, batch_size = 32)
   batch <- dataloader_next(dataloader_make_iter(dl))
@@ -53,10 +44,7 @@ test_that("tests for the LFW People dataset for dataloader", {
 })
 
 test_that("tests for the LFW Pairs dataset for original image_set train split", {
-  # MacOS runner fails with cannot open URL 'https://ndownloader.figshare.com/files/5976015'
-  skip_on_os("mac")
-  skip_on_os("windows")
-  skip_on_os("linux")
+
   lfw <- lfw_pairs_dataset(root = t, download = TRUE, split = "original", train = TRUE)
   expect_length(lfw, 2200)
   first_item <- lfw[1]
@@ -70,10 +58,7 @@ test_that("tests for the LFW Pairs dataset for original image_set train split", 
 })
 
 test_that("tests for the LFW Pairs dataset for funneled image_set train split", {
-  # MacOS runner fails with cannot open URL 'https://ndownloader.figshare.com/files/5976015'
-  skip_on_os("mac")
-  skip_on_os("windows")
-  skip_on_os("linux")
+
   lfw <- lfw_pairs_dataset(root = t, train = TRUE, split = "funneled", download = TRUE)
   expect_length(lfw, 2200)
   first_item <- lfw[1]
@@ -87,10 +72,7 @@ test_that("tests for the LFW Pairs dataset for funneled image_set train split", 
 })
 
 test_that("tests for the LFW Pairs dataset for original image_set test split", {
-  # MacOS runner fails with cannot open URL 'https://ndownloader.figshare.com/files/5976015'
-  skip_on_os("mac")
-  skip_on_os("windows")
-  skip_on_os("linux")
+
   lfw <- lfw_pairs_dataset(root = t, split = "original", train = FALSE)
   expect_length(lfw, 1000)
   first_item <- lfw[1]
@@ -104,10 +86,7 @@ test_that("tests for the LFW Pairs dataset for original image_set test split", {
 })
 
 test_that("tests for the LFW Pairs dataset for funneled image_set test split", {
-  # MacOS runner fails with cannot open URL 'https://ndownloader.figshare.com/files/5976015'
-  skip_on_os("mac")
-  skip_on_os("windows")
-  skip_on_os("linux")
+
   lfw <- lfw_pairs_dataset(root = t, train = FALSE, split = "funneled")
   expect_length(lfw, 1000)
   first_item <- lfw[1]
@@ -121,9 +100,7 @@ test_that("tests for the LFW Pairs dataset for funneled image_set test split", {
 })
 
 test_that("tests for the LFW People dataset for dataloader", {
-  # MacOS runner fails with cannot open URL 'https://ndownloader.figshare.com/files/5976015'
-  skip_on_os("mac")
-  skip_on_os("windows")
+
   lfw <- lfw_pairs_dataset(
     root = t,
     transform = function(pair) {


### PR DESCRIPTION
- Use HuggingFace mirror for LFW dataset downloads
- Remove OS skips from LFW tests

Fixes #267 