### PR TITLE
fix: honour aux_logits = FALSE for pretrained inception_v3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 
 * `nms()` now uses `torchvisionlib::ops_nms()` when torchvisionlib is installed, speeding up inference for `model_fasterrcnn_*()` and `model_maskrcnn_*()` (#321, #322).
 * Lists and vectors are now preallocated to their target size instead of being grown one element at a time (@srishtiii28, #335).
+* `model_inception_v3(pretrained = TRUE, aux_logits = FALSE)` now actually removes the auxiliary classifier. Previously `aux_logits = FALSE` was silently ignored for pretrained models, so the network returned a list of both heads instead of a single tensor in training mode.
 
 
 # torchvision 0.9.0

--- a/R/models-inception.R
+++ b/R/models-inception.R
@@ -438,6 +438,18 @@ model_inception_v3 <-function(pretrained = FALSE, progress = TRUE, ...) {
 
     state_dict <- torch::load_state_dict(state_dict_path)
     model$load_state_dict(state_dict)
+
+    # The auxiliary branch had to be enabled above so that the pretrained state dict, which
+    # contains the `AuxLogits.*` tensors, can be loaded. Now that the weights are in place we can
+    # honour the `aux_logits = FALSE` that the caller asked for. Note that assigning `NULL` does
+    # not deregister a submodule in torch for R, so the branch is replaced by `nn_identity()`,
+    # which drops its parameters. Both `aux_logits` and `AuxLogits` have to be reset, because
+    # `forward()` dispatches on the former and `.forward()` on the latter.
+    if (!original_aux_logits) {
+      model$aux_logits <- FALSE
+      model$AuxLogits <- torch::nn_identity()
+    }
+
     return(model)
   }
 

--- a/tests/testthat/test-models-inception.R
+++ b/tests/testthat/test-models-inception.R
@@ -6,3 +6,47 @@ test_that("inception_v3 pretrained", {
   expect_equal(as.numeric(x[1,1]), 0.18005196750164032, tol = 5e-6)
   expect_tensor_shape(x, c(2, 1000))
 })
+
+test_that("inception_v3 keeps the auxiliary branch by default", {
+  model <- model_inception_v3(pretrained = FALSE, init_weights = FALSE)
+  expect_true(model$aux_logits)
+
+  # in training mode both heads are returned, in evaluation mode only the logits
+  model$train()
+  out <- model(torch_ones(2, 3, 299, 299))
+  expect_named(out, c("logits", "aux_logits"))
+  expect_tensor_shape(out$logits, c(2, 1000))
+  expect_tensor_shape(out$aux_logits, c(2, 1000))
+
+  model$eval()
+  expect_tensor_shape(model(torch_ones(2, 3, 299, 299)), c(2, 1000))
+})
+
+test_that("inception_v3 respects aux_logits = FALSE", {
+  model <- model_inception_v3(pretrained = FALSE, aux_logits = FALSE, init_weights = FALSE)
+  expect_false(model$aux_logits)
+
+  # without the auxiliary branch a single tensor is returned, also in training mode
+  model$train()
+  expect_tensor_shape(model(torch_ones(2, 3, 299, 299)), c(2, 1000))
+})
+
+test_that("inception_v3 pretrained respects aux_logits = FALSE", {
+  # the auxiliary branch has to be enabled while the state dict is loaded, but must be removed
+  # afterwards, including its parameters
+  model <- model_inception_v3(pretrained = TRUE, aux_logits = FALSE)
+  expect_false(model$aux_logits)
+
+  reference <- model_inception_v3(pretrained = FALSE, aux_logits = FALSE, init_weights = FALSE)
+  expect_equal(length(model$parameters), length(reference$parameters))
+
+  # the weights that are kept are still the pretrained ones
+  model$eval()
+  x <- model(torch_ones(2, 3, 299, 299))
+  expect_equal(as.numeric(x[1,1]), 0.18005196750164032, tol = 5e-6)
+
+  # a single tensor is returned, also in training mode. This has to be checked after the value
+  # above, because a forward pass in training mode updates the batch norm statistics.
+  model$train()
+  expect_tensor_shape(model(torch_ones(2, 3, 299, 299)), c(2, 1000))
+})


### PR DESCRIPTION
`model_inception_v3()` forces `aux_logits = TRUE` when `pretrained = TRUE`, because the published state dict contains the `AuxLogits.*` tensors and would otherwise not load. The caller's original value was stored in `original_aux_logits`, but never used again, so `aux_logits = FALSE` was silently ignored for pretrained models.

As a consequence the network returned a `list(logits, aux_logits)` instead of a single tensor in training mode, which breaks generic training loops, and the parameters of the auxiliary branch were handed to the optimizer without ever receiving a gradient.

The auxiliary branch is now removed after the state dict has been loaded. Note that assigning `NULL` does not deregister a submodule in torch for R, hence `nn_identity()` is used, which brings the parameter count in line with a model that was constructed with `aux_logits = FALSE` from the start.