### PR TITLE
fix: correct shape and value bugs in the image transforms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,21 @@
 
 ## Bug fixes and improvements
 
+* `transform_crop()` now pads the result with zeros when the crop leaves the image, so that the
+  output always has the requested size. It previously returned only the part of the image the crop
+  covered, which could even be empty.
+* `transform_center_crop()` now pads correctly when the requested `size` is not square. Height and
+  width were used in the wrong order in the padding branch, so e.g. cropping a `(16, 20)` image to
+  `c(24, 30)` returned a `(22, 0)` image.
+* `transform_rgb_to_grayscale()` now returns an image with one channel instead of dropping the
+  channel dimension, i.e. `(3, H, W)` becomes `(1, H, W)` and not `(H, W)`. This also fixes
+  `transform_grayscale()` for batched input.
+* `hsv2rgb()` computed the fractional part of the hue sector and the `t` component incorrectly, so
+  converting an image to HSV and back did not return the original image. This affected
+  `transform_adjust_hue()` and `transform_color_jitter(hue = ...)`.
+* `transform_adjust_hue()` now handles negative `hue_factor`s, which produced a black image before,
+  and rejects images that do not have 1 or 3 channels instead of silently dropping the additional
+  ones.
 * `nms()` now uses `torchvisionlib::ops_nms()` when torchvisionlib is installed, speeding up inference for `model_fasterrcnn_*()` and `model_maskrcnn_*()` (#321, #322).
 * Lists and vectors are now preallocated to their target size instead of being grown one element at a time (@srishtiii28, #335).
 

--- a/R/transforms-defaults.R
+++ b/R/transforms-defaults.R
@@ -48,9 +48,10 @@ transform_center_crop.default <- function(img, size) {
 
     img <- transform_pad(img, padding_ltrb, fill = 0)  # PIL uses fill value 0
 
+    # `get_image_size()` returns (width, height), as above
     size <- get_image_size(img)
-    image_height <- size[1]
-    image_width <- size[2]
+    image_height <- size[2]
+    image_width <- size[1]
 
     if (crop_width == image_width && crop_height == image_height) return(img)
   }

--- a/R/transforms-tensor.R
+++ b/R/transforms-tensor.R
@@ -334,7 +334,31 @@ transform_grayscale.torch_tensor <- function(img, num_output_channels) {
 transform_crop.torch_tensor <- function(img, top, left, height, width) {
   check_img(img)
 
-  img[.., top:(top + height - 1), left:(left + width - 1)]
+  size <- get_image_size(img)
+  image_width <- size[1]
+  image_height <- size[2]
+
+  bottom <- top + height - 1
+  right <- left + width - 1
+
+  # A crop that leaves the image is padded with zeros, so that the output always has the requested
+  # size, as in torchvision for python.
+  pad_top <- max(1 - top, 0)
+  pad_left <- max(1 - left, 0)
+  pad_bottom <- max(bottom - image_height, 0)
+  pad_right <- max(right - image_width, 0)
+
+  if (pad_top == 0 && pad_left == 0 && pad_bottom == 0 && pad_right == 0)
+    return(img[.., top:bottom, left:right])
+
+  # the crop can also lie entirely outside the image, in which case there is nothing to index
+  if (bottom < 1 || right < 1 || top > image_height || left > image_width) {
+    out_size <- c(utils::head(img$size(), -2), height, width)
+    return(torch::torch_zeros(out_size, dtype = img$dtype, device = img$device))
+  }
+
+  cropped <- img[.., max(top, 1):min(bottom, image_height), max(left, 1):min(right, image_width)]
+  transform_pad(cropped, c(pad_left, pad_right, pad_top, pad_bottom), fill = 0)
 }
 
 #' @export
@@ -380,6 +404,14 @@ transform_adjust_hue.torch_tensor <- function(img, hue_factor) {
 
   check_img(img)
 
+  channels <- tail(head(img$size(), -2), 1)
+  if (!channels %in% c(1, 3))
+    value_error("Input image tensor permitted channel values are 1 or 3, but found {channels}.")
+
+  # a single-channel image has no hue to adjust, as in torchvision for python
+  if (channels == 1)
+    return(img)
+
   orig_dtype <- img$dtype
   if (img$dtype == torch::torch_uint8())
     img <- img$to(dtype = torch::torch_float32())/255
@@ -389,7 +421,9 @@ transform_adjust_hue.torch_tensor <- function(img, hue_factor) {
   channel_dim <- if (img$ndim == 3) 1 else 2
   hsv <- img$unbind(channel_dim)
   hsv[[1]] <- hsv[[1]] + hue_factor
-  hsv[[1]] <- hsv[[1]] %% 1
+  # `%%` is `fmod()` for tensors and keeps the sign of the dividend, so a negative `hue_factor`
+  # would give a negative hue; the hue wraps around instead
+  hsv[[1]] <- torch::torch_remainder(hsv[[1]], 1)
   img <- torch::torch_stack(hsv, dim=channel_dim)
   img_hue_adj <- hsv2rgb(img)
 
@@ -479,7 +513,10 @@ transform_perspective.torch_tensor <- function(img, startpoints, endpoints, inte
 #' @export
 transform_rgb_to_grayscale.torch_tensor <- function(img) {
   check_img(img)
-  (0.2989 * img[..,1,,] + 0.5870 * img[..,2,,] + 0.1140 * img[..,3,,])$to(img$dtype)
+  gray <- (0.2989 * img[..,1,,] + 0.5870 * img[..,2,,] + 0.1140 * img[..,3,,])$to(img$dtype)
+  # indexing the channels drops their dimension, but the result is a single-channel image and must
+  # keep the same number of dimensions as the input, as in torchvision for python
+  gray$unsqueeze(-3)
 }
 
 # Helpers -----------------------------------------------------------------
@@ -557,12 +594,13 @@ hsv2rgb <- function(img) {
 
   hsv <- img$unbind(channel_dim)
   i <- torch::torch_floor(hsv[[1]] * 6)
-  f <- (hsv[[1]] * 6) - 1
+  # `f` is the fractional part of the sector, i.e. the distance to the sector `i` starts at
+  f <- (hsv[[1]] * 6) - i
   i <- i$to(dtype = torch::torch_int32())
 
   p <- torch::torch_clamp((hsv[[3]] * (1 - hsv[[2]])), 0, 1)
   q <- torch::torch_clamp((hsv[[3]] * (1 - hsv[[2]] * f)), 0, 1)
-  t <- torch::torch_clamp((hsv[[3]] * (1 - f)), 0, 1)
+  t <- torch::torch_clamp((hsv[[3]] * (1 - hsv[[2]] * (1 - f))), 0, 1)
   i <- i %% 6
 
   mask <- if (img$ndim == 3)

--- a/tests/testthat/test-transforms-defaults.R
+++ b/tests/testthat/test-transforms-defaults.R
@@ -9,3 +9,21 @@ test_that("random_resized_crop", {
   expect_tensor_shape(transform_to_tensor(o), c(3, 32, 32))
 
 })
+
+test_that("center_crop pads a non-square size correctly", {
+  x <- torch_ones(3, 16, 20)
+
+  # no padding needed
+  expect_equal(dim(transform_center_crop(x, c(8, 10))), c(3, 8, 10))
+
+  # padded on both axes, on one axis only, and with a square size
+  expect_equal(dim(transform_center_crop(x, c(24, 30))), c(3, 24, 30))
+  expect_equal(dim(transform_center_crop(x, c(24, 10))), c(3, 24, 10))
+  expect_equal(dim(transform_center_crop(x, c(8, 30))), c(3, 8, 30))
+  expect_equal(dim(transform_center_crop(x, 32)), c(3, 32, 32))
+
+  # the image ends up centred in the padding
+  o <- transform_center_crop(torch_ones(1, 2, 2), c(4, 6))
+  expect_equal(as.numeric(o$sum()), 4)
+  expect_equal_to_r(o[1, 2:3, 3:4], matrix(1, nrow = 2, ncol = 2))
+})

--- a/tests/testthat/test-transforms-defaults.R
+++ b/tests/testthat/test-transforms-defaults.R
@@ -14,13 +14,13 @@ test_that("center_crop pads a non-square size correctly", {
   x <- torch_ones(3, 16, 20)
 
   # no padding needed
-  expect_equal(dim(transform_center_crop(x, c(8, 10))), c(3, 8, 10))
+  expect_tensor_shape(transform_center_crop(x, c(8, 10)), c(3, 8, 10))
 
   # padded on both axes, on one axis only, and with a square size
-  expect_equal(dim(transform_center_crop(x, c(24, 30))), c(3, 24, 30))
-  expect_equal(dim(transform_center_crop(x, c(24, 10))), c(3, 24, 10))
-  expect_equal(dim(transform_center_crop(x, c(8, 30))), c(3, 8, 30))
-  expect_equal(dim(transform_center_crop(x, 32)), c(3, 32, 32))
+  expect_tensor_shape(transform_center_crop(x, c(24, 30)), c(3, 24, 30))
+  expect_tensor_shape(transform_center_crop(x, c(24, 10)), c(3, 24, 10))
+  expect_tensor_shape(transform_center_crop(x, c(8, 30)), c(3, 8, 30))
+  expect_tensor_shape(transform_center_crop(x, 32), c(3, 32, 32))
 
   # the image ends up centred in the padding
   o <- transform_center_crop(torch_ones(1, 2, 2), c(4, 6))

--- a/tests/testthat/test-transforms-tensor.R
+++ b/tests/testthat/test-transforms-tensor.R
@@ -5,12 +5,12 @@ test_that("convert_image_dtype", {
   o <- transform_convert_image_dtype(x, torch_int16())
   y <- transform_convert_image_dtype(o, torch_float32())
 
-  expect_equal(round(as_array(x),1), round(as_array(y),1))
+  expect_equal_to_r(x, as_array(y), tolerance  = 1e-4)
 
   ob <- transform_convert_image_dtype(x$unsqueeze(1), torch_int16())
   yb <- transform_convert_image_dtype(ob, torch_float32())
 
-  expect_equal(round(as_array(x$unsqueeze(1)),1), round(as_array(yb),1))
+  expect_equal_to_r(x$unsqueeze(1), as_array(yb), tolerance  = 1e-4)
 
 })
 
@@ -441,20 +441,20 @@ test_that("random vertical flip", {
 
   for (i in 1:10) {
     out <- transform_random_vertical_flip(tensor)
-    expect_equal(dim(out), dim(tensor))
+    expect_tensor_shape(out, dim(tensor))
   }
   for (p in seq(0, 1, length.out = 10)) {
     out <- transform_random_vertical_flip(tensor, p)
-    expect_equal(dim(out), dim(tensor))
+    expect_tensor_shape(out, dim(tensor))
   }
 
   for (i in 1:10) {
     outb <- transform_random_vertical_flip(tensor$unsqueeze(1))
-    expect_equal(dim(outb), dim(tensor$unsqueeze(1)))
+    expect_tensor_shape(outb, dim(tensor$unsqueeze(1)))
   }
   for (p in seq(0, 1, length.out = 10)) {
     outb <- transform_random_vertical_flip(tensor$unsqueeze(1), p)
-    expect_equal(dim(outb), dim(tensor$unsqueeze(1)))
+    expect_tensor_shape(outb, dim(tensor$unsqueeze(1)))
   }
 })
 
@@ -466,8 +466,8 @@ test_that("random rotation works", {
   # Transforms
   rotate <- function(img) transform_random_rotation(img, 20)
 
-  expect_error(rotate(x), regexp = NA)
-  expect_error(rotate(x$unsqueeze(1)), regexp = NA)
+  expect_no_error(rotate(x))
+  expect_no_error(rotate(x$unsqueeze(1)))
 
 
 })
@@ -488,8 +488,7 @@ test_that("random choice transform works", {
   identity <- function(img) img
 
   # Select a Random Transform to Apply
-  expect_error(regexp = NA, {
-    transform_random_choice(
+  expect_no_error(transform_random_choice(
       x,
       list(
         color_transform,
@@ -500,10 +499,9 @@ test_that("random choice transform works", {
         identity
       )
     )
-  })
+  )
 
-  expect_error(regexp = NA, {
-    transform_random_choice(
+  expect_no_error(transform_random_choice(
       x$unsqueeze(1),
       list(
         color_transform,
@@ -514,7 +512,7 @@ test_that("random choice transform works", {
         identity
       )
     )
-  })
+  )
 
 })
 
@@ -527,15 +525,15 @@ test_that("crop pads when the crop leaves the image", {
 
   # partially outside: the requested size, the overlap unchanged, zeros elsewhere
   o <- transform_crop(x, top = 3, left = 5, height = 4, width = 4)
-  expect_equal(dim(o), c(1, 4, 4))
+  expect_tensor_shape(o, c(1, 4, 4))
   expect_equal_to_r(o[, 1:2, 1:2], as_array(x[, 3:4, 5:6]))
-  expect_equal(as.numeric(o$sum()), as.numeric(x[, 3:4, 5:6]$sum()))
+  expect_equal_to_r(o$sum(), as_array(x[, 3:4, 5:6]$sum()))
 
   # a start before the image pads on the top and the left
   o <- transform_crop(x, top = -1, left = 0, height = 4, width = 4)
-  expect_equal(dim(o), c(1, 4, 4))
-  expect_equal(as.numeric(o[, 1:2, ]$sum()), 0)          # the two padded rows
-  expect_equal(as.numeric(o[, , 1]$sum()), 0)            # the padded column
+  expect_tensor_shape(o, c(1, 4, 4))
+  expect_equal_to_r(o[, 1:2, ]$sum(), 0)          # the two padded rows
+  expect_equal_to_r(o[, , 1]$sum(), 0)            # the padded column
   expect_equal_to_r(o[, 3:4, 2:4], as_array(x[, 1:2, 1:3]))
 
   # fully outside: all zeros, but still the requested size
@@ -570,60 +568,60 @@ test_that("rgb_to_grayscale keeps the channel dimension", {
   # every repeated channel is the same grayscale image
   expect_equal_to_r(g3[2, , ], as_array(o[1, , ]))
   expect_equal_to_r(g3[3, , ], as_array(o[1, , ]))
-  expect_equal(dim(transform_grayscale(x$unsqueeze(1), num_output_channels = 3)), c(1, 3, 4, 6))
+  expect_tensor_shape(transform_grayscale(x$unsqueeze(1), num_output_channels = 3), c(1, 3, 4, 6))
 
   # the dtype is preserved
   xi <- torch_ones(3, 2, 2, dtype = torch_uint8())
-  expect_true(transform_rgb_to_grayscale(xi)$dtype == torch_uint8())
+  expect_tensor_dtype(transform_rgb_to_grayscale(xi), torch_uint8())
 
   # the operators that build on it are unaffected by the extra dimension
-  expect_equal(dim(transform_adjust_saturation(x, 1.5)), c(3, 4, 6))
-  expect_equal(dim(transform_adjust_contrast(x, 1.5)), c(3, 4, 6))
+  expect_tensor_shape(transform_adjust_saturation(x, 1.5), c(3, 4, 6))
+  expect_tensor_shape(transform_adjust_contrast(x, 1.5), c(3, 4, 6))
 })
 
 test_that("rgb2hsv and hsv2rgb are inverse to each other", {
   x <- torch_rand(3, 8, 10)
-  expect_equal(round(as_array(hsv2rgb(rgb2hsv(x))), 4), round(as_array(x), 4))
+  expect_equal_to_r(hsv2rgb(rgb2hsv(x)), as_array(x), tolerance = 1e-6)
 
   b <- torch_rand(2, 3, 8, 10)
-  expect_equal(round(as_array(hsv2rgb(rgb2hsv(b))), 4), round(as_array(b), 4))
+  expect_equal_to_r(hsv2rgb(rgb2hsv(b)), as_array(b), tolerance = 1e-6)
 
   # known colours: (h, s, v) of pure red is (0, 1, 1), of pure blue (2/3, 1, 1)
   red <- torch_tensor(array(c(1, 0, 0), dim = c(3, 1, 1)))
-  expect_equal(round(as.numeric(rgb2hsv(red)), 4), c(0, 1, 1))
+  expect_equal_to_r(rgb2hsv(red), array(c(0, 1, 1),dim = c(3,1,1)), tolerance = 1e-7)
   blue <- torch_tensor(array(c(0, 0, 1), dim = c(3, 1, 1)))
-  expect_equal(round(as.numeric(rgb2hsv(blue)), 4), round(c(2 / 3, 1, 1), 4))
+  expect_equal_to_r(rgb2hsv(blue), array(c(2 / 3, 1, 1),dim = c(3,1,1)), tolerance = 1e-7)
 })
 
 test_that("adjust_hue rotates the hue in both directions", {
   red <- torch_tensor(array(c(1, 0, 0), dim = c(3, 1, 1)))
   # a third of the hue wheel takes red to green, and back to blue in the other direction
-  expect_equal(round(as.numeric(transform_adjust_hue(red, 1 / 3)), 3), c(0, 1, 0))
-  expect_equal(round(as.numeric(transform_adjust_hue(red, -1 / 3)), 3), c(0, 0, 1))
+  expect_equal_to_r(transform_adjust_hue(red, 1 / 3), array(c(0, 1, 0), dim = c(3, 1, 1)))
+  expect_equal_to_r(transform_adjust_hue(red, -1 / 3), array(c(0, 0, 1), dim = c(3, 1, 1)), tolerance = 1e-6)
   # half a turn is the same in both directions
-  expect_equal(round(as.numeric(transform_adjust_hue(red, 0.5)), 3), c(0, 1, 1))
-  expect_equal(round(as.numeric(transform_adjust_hue(red, -0.5)), 3), c(0, 1, 1))
+  expect_equal_to_r(transform_adjust_hue(red, 0.5), array(c(0, 1, 1), dim = c(3, 1, 1)))
+  expect_equal_to_r(transform_adjust_hue(red, -0.5), array(c(0, 1, 1), dim = c(3, 1, 1)))
 
   x <- torch_rand(3, 4, 6)
   # a hue factor of 0 leaves the image unchanged, and opposite rotations cancel out
-  expect_equal(round(as_array(transform_adjust_hue(x, 0)), 4), round(as_array(x), 4))
-  expect_equal(
-    round(as_array(transform_adjust_hue(transform_adjust_hue(x, -0.5), 0.5)), 4),
-    round(as_array(x), 4)
+  expect_equal_to_r(transform_adjust_hue(x, 0), as_array(x), tolerance = 1e-6)
+  expect_equal_to_r(
+    transform_adjust_hue(transform_adjust_hue(x, -0.5), 0.5),
+    as_array(x), tolerance = 1e-6
   )
-  expect_equal(
-    round(as_array(transform_adjust_hue(transform_adjust_hue(x, -0.25), -0.25)), 4),
-    round(as_array(transform_adjust_hue(x, -0.5)), 4)
+  expect_equal_to_r(
+    transform_adjust_hue(transform_adjust_hue(x, -0.25), -0.25),
+    as_array(transform_adjust_hue(x, -0.5)), tolerance = 1e-6
   )
 
   # uint8 images keep their dtype
   xi <- (x * 255)$to(dtype = torch_uint8())
-  expect_true(transform_adjust_hue(xi, 0.2)$dtype == torch_uint8())
+  expect_tensor_dtype(transform_adjust_hue(xi, 0.2), torch_uint8())
 })
 
 test_that("adjust_hue only accepts 1 or 3 channels", {
   x <- torch_rand(3, 4, 6)
-  expect_equal(dim(transform_adjust_hue(x, 0.2)), c(3, 4, 6))
+  expect_tensor_shape(transform_adjust_hue(x, 0.2), c(3, 4, 6))
 
   # a single channel has no hue to adjust and is returned unchanged
   gray <- torch_rand(1, 4, 6)

--- a/tests/testthat/test-transforms-tensor.R
+++ b/tests/testthat/test-transforms-tensor.R
@@ -374,11 +374,11 @@ test_that("linear transformation", {
 
   out <- transform_linear_transformation(tensor, matrix, mean_vector)
 
-  expect_equal(dim(out), c(3, 24, 32))
+  expect_tensor_shape(out, c(3, 24, 32))
 
   outb <- transform_linear_transformation(tensor$unsqueeze(1), matrix, mean_vector)
 
-  expect_equal(dim(outb), c(1, 3, 24, 32))
+  expect_tensor_shape(outb, c(1, 3, 24, 32))
 })
 
 test_that("adjust hue", {
@@ -388,12 +388,12 @@ test_that("adjust hue", {
 
   for (f in hue_factor) {
     out <- transform_adjust_hue(x, f)
-    expect_equal(dim(out), dim(x))
+    expect_tensor_shape(out, dim(x))
   }
 
   for (f in hue_factor) {
     out <- transform_adjust_hue(x$unsqueeze(1), f)
-    expect_equal(dim(out), dim(x$unsqueeze(1)))
+    expect_tensor_shape(out, dim(x$unsqueeze(1)))
   }
 
 })
@@ -402,7 +402,7 @@ test_that("grayscale", {
 
   x <- torch::torch_rand(3, 24, 32)
   out <- transform_grayscale(x, 3)
-  expect_equal(dim(out), dim(x))
+  expect_tensor_shape(out, dim(x))
   expect_equal(dim(out)[1], 3)
 
   out <- transform_grayscale(x, 1)
@@ -410,7 +410,7 @@ test_that("grayscale", {
   expect_equal(dim(out)[1], 1)
 
   outb <- transform_grayscale(x$unsqueeze(1), 3)
-  expect_equal(dim(outb), dim(x$unsqueeze(1)))
+  expect_tensor_shape(outb, dim(x$unsqueeze(1)))
   expect_equal(dim(outb)[2], 3)
 
   outb <- transform_grayscale(x$unsqueeze(1), 1)
@@ -424,12 +424,12 @@ test_that("random grayscale", {
   tensor <- torch::torch_rand(3, 24, 32)
   for (p in seq(0, 1, length.out = 10)) {
     out <- transform_random_grayscale(tensor, p)
-    expect_equal(dim(out), dim(tensor))
+    expect_tensor_shape(out, dim(tensor))
   }
 
   for (p in seq(0, 1, length.out = 10)) {
     outb <- transform_random_grayscale(tensor$unsqueeze(1), p)
-    expect_equal(dim(outb), dim(tensor$unsqueeze(1)))
+    expect_tensor_shape(outb, dim(tensor$unsqueeze(1)))
   }
 
 })
@@ -538,33 +538,30 @@ test_that("crop pads when the crop leaves the image", {
 
   # fully outside: all zeros, but still the requested size
   o <- transform_crop(x, top = 30, left = 30, height = 4, width = 4)
-  expect_equal(dim(o), c(1, 4, 4))
-  expect_equal(as.numeric(o$sum()), 0)
+  expect_tensor_shape(o, c(1, 4, 4))
+  expect_equal_to_r(o$sum(), 0)
 
   # batch tensors behave the same way
   expect_equal(dim(transform_crop(x$unsqueeze(1), 3, 5, 4, 4)), c(1, 1, 4, 4))
 
   # the dtype is preserved, also on the padded path
   xi <- torch_ones(1, 2, 2, dtype = torch_long())
-  expect_true(transform_crop(xi, 1, 1, 4, 4)$dtype == torch_long())
-  expect_true(transform_crop(xi, 1, 1, 2, 2)$dtype == torch_long())
+  expect_tensor_dtype(transform_crop(xi, 1, 1, 4, 4), torch_long())
+  expect_tensor_dtype(transform_crop(xi, 1, 1, 2, 2), torch_long())
 })
 
 test_that("rgb_to_grayscale keeps the channel dimension", {
   x <- torch_rand(3, 4, 6)
   o <- transform_rgb_to_grayscale(x)
-  expect_equal(dim(o), c(1, 4, 6))
+  expect_tensor_shape(o, c(1, 4, 6))
   # the values are the usual luminance weights
-  expect_equal(
-    round(as_array(o[1, , ]), 5),
-    round(as_array(0.2989 * x[1, , ] + 0.5870 * x[2, , ] + 0.1140 * x[3, , ]), 5)
-  )
-  expect_equal(dim(transform_rgb_to_grayscale(x$unsqueeze(1))), c(1, 1, 4, 6))
+  expect_equal_to_r(o[1, , ],  as_array(0.2989 * x[1, , ] + 0.5870 * x[2, , ] + 0.1140 * x[3, , ]))
+  expect_tensor_shape(transform_rgb_to_grayscale(x$unsqueeze(1)), c(1, 1, 4, 6))
 
   # `transform_grayscale()` repeats that channel, also for batch tensors
-  expect_equal(dim(transform_grayscale(x, num_output_channels = 1)), c(1, 4, 6))
+  expect_tensor_shape(transform_grayscale(x, num_output_channels = 1), c(1, 4, 6))
   g3 <- transform_grayscale(x, num_output_channels = 3)
-  expect_equal(dim(g3), c(3, 4, 6))
+  expect_tensor_shape(g3, c(3, 4, 6))
   # every repeated channel is the same grayscale image
   expect_equal_to_r(g3[2, , ], as_array(o[1, , ]))
   expect_equal_to_r(g3[3, , ], as_array(o[1, , ]))

--- a/tests/testthat/test-transforms-tensor.R
+++ b/tests/testthat/test-transforms-tensor.R
@@ -518,3 +518,120 @@ test_that("random choice transform works", {
 
 })
 
+
+test_that("crop pads when the crop leaves the image", {
+  x <- torch_arange(1, 24)$reshape(c(1, 4, 6))
+
+  # fully inside: identical to indexing the image
+  expect_equal_to_r(transform_crop(x, 2, 3, 2, 3), as_array(x[, 2:3, 3:5]))
+
+  # partially outside: the requested size, the overlap unchanged, zeros elsewhere
+  o <- transform_crop(x, top = 3, left = 5, height = 4, width = 4)
+  expect_equal(dim(o), c(1, 4, 4))
+  expect_equal_to_r(o[, 1:2, 1:2], as_array(x[, 3:4, 5:6]))
+  expect_equal(as.numeric(o$sum()), as.numeric(x[, 3:4, 5:6]$sum()))
+
+  # a start before the image pads on the top and the left
+  o <- transform_crop(x, top = -1, left = 0, height = 4, width = 4)
+  expect_equal(dim(o), c(1, 4, 4))
+  expect_equal(as.numeric(o[, 1:2, ]$sum()), 0)          # the two padded rows
+  expect_equal(as.numeric(o[, , 1]$sum()), 0)            # the padded column
+  expect_equal_to_r(o[, 3:4, 2:4], as_array(x[, 1:2, 1:3]))
+
+  # fully outside: all zeros, but still the requested size
+  o <- transform_crop(x, top = 30, left = 30, height = 4, width = 4)
+  expect_equal(dim(o), c(1, 4, 4))
+  expect_equal(as.numeric(o$sum()), 0)
+
+  # batch tensors behave the same way
+  expect_equal(dim(transform_crop(x$unsqueeze(1), 3, 5, 4, 4)), c(1, 1, 4, 4))
+
+  # the dtype is preserved, also on the padded path
+  xi <- torch_ones(1, 2, 2, dtype = torch_long())
+  expect_true(transform_crop(xi, 1, 1, 4, 4)$dtype == torch_long())
+  expect_true(transform_crop(xi, 1, 1, 2, 2)$dtype == torch_long())
+})
+
+test_that("rgb_to_grayscale keeps the channel dimension", {
+  x <- torch_rand(3, 4, 6)
+  o <- transform_rgb_to_grayscale(x)
+  expect_equal(dim(o), c(1, 4, 6))
+  # the values are the usual luminance weights
+  expect_equal(
+    round(as_array(o[1, , ]), 5),
+    round(as_array(0.2989 * x[1, , ] + 0.5870 * x[2, , ] + 0.1140 * x[3, , ]), 5)
+  )
+  expect_equal(dim(transform_rgb_to_grayscale(x$unsqueeze(1))), c(1, 1, 4, 6))
+
+  # `transform_grayscale()` repeats that channel, also for batch tensors
+  expect_equal(dim(transform_grayscale(x, num_output_channels = 1)), c(1, 4, 6))
+  g3 <- transform_grayscale(x, num_output_channels = 3)
+  expect_equal(dim(g3), c(3, 4, 6))
+  # every repeated channel is the same grayscale image
+  expect_equal_to_r(g3[2, , ], as_array(o[1, , ]))
+  expect_equal_to_r(g3[3, , ], as_array(o[1, , ]))
+  expect_equal(dim(transform_grayscale(x$unsqueeze(1), num_output_channels = 3)), c(1, 3, 4, 6))
+
+  # the dtype is preserved
+  xi <- torch_ones(3, 2, 2, dtype = torch_uint8())
+  expect_true(transform_rgb_to_grayscale(xi)$dtype == torch_uint8())
+
+  # the operators that build on it are unaffected by the extra dimension
+  expect_equal(dim(transform_adjust_saturation(x, 1.5)), c(3, 4, 6))
+  expect_equal(dim(transform_adjust_contrast(x, 1.5)), c(3, 4, 6))
+})
+
+test_that("rgb2hsv and hsv2rgb are inverse to each other", {
+  x <- torch_rand(3, 8, 10)
+  expect_equal(round(as_array(hsv2rgb(rgb2hsv(x))), 4), round(as_array(x), 4))
+
+  b <- torch_rand(2, 3, 8, 10)
+  expect_equal(round(as_array(hsv2rgb(rgb2hsv(b))), 4), round(as_array(b), 4))
+
+  # known colours: (h, s, v) of pure red is (0, 1, 1), of pure blue (2/3, 1, 1)
+  red <- torch_tensor(array(c(1, 0, 0), dim = c(3, 1, 1)))
+  expect_equal(round(as.numeric(rgb2hsv(red)), 4), c(0, 1, 1))
+  blue <- torch_tensor(array(c(0, 0, 1), dim = c(3, 1, 1)))
+  expect_equal(round(as.numeric(rgb2hsv(blue)), 4), round(c(2 / 3, 1, 1), 4))
+})
+
+test_that("adjust_hue rotates the hue in both directions", {
+  red <- torch_tensor(array(c(1, 0, 0), dim = c(3, 1, 1)))
+  # a third of the hue wheel takes red to green, and back to blue in the other direction
+  expect_equal(round(as.numeric(transform_adjust_hue(red, 1 / 3)), 3), c(0, 1, 0))
+  expect_equal(round(as.numeric(transform_adjust_hue(red, -1 / 3)), 3), c(0, 0, 1))
+  # half a turn is the same in both directions
+  expect_equal(round(as.numeric(transform_adjust_hue(red, 0.5)), 3), c(0, 1, 1))
+  expect_equal(round(as.numeric(transform_adjust_hue(red, -0.5)), 3), c(0, 1, 1))
+
+  x <- torch_rand(3, 4, 6)
+  # a hue factor of 0 leaves the image unchanged, and opposite rotations cancel out
+  expect_equal(round(as_array(transform_adjust_hue(x, 0)), 4), round(as_array(x), 4))
+  expect_equal(
+    round(as_array(transform_adjust_hue(transform_adjust_hue(x, -0.5), 0.5)), 4),
+    round(as_array(x), 4)
+  )
+  expect_equal(
+    round(as_array(transform_adjust_hue(transform_adjust_hue(x, -0.25), -0.25)), 4),
+    round(as_array(transform_adjust_hue(x, -0.5)), 4)
+  )
+
+  # uint8 images keep their dtype
+  xi <- (x * 255)$to(dtype = torch_uint8())
+  expect_true(transform_adjust_hue(xi, 0.2)$dtype == torch_uint8())
+})
+
+test_that("adjust_hue only accepts 1 or 3 channels", {
+  x <- torch_rand(3, 4, 6)
+  expect_equal(dim(transform_adjust_hue(x, 0.2)), c(3, 4, 6))
+
+  # a single channel has no hue to adjust and is returned unchanged
+  gray <- torch_rand(1, 4, 6)
+  expect_equal_to_r(transform_adjust_hue(gray, 0.2), as_array(gray))
+  expect_equal_to_r(transform_adjust_hue(gray$unsqueeze(1), 0.2), as_array(gray$unsqueeze(1)))
+
+  expect_error(transform_adjust_hue(torch_rand(4, 4, 6), 0.2), "channel values are 1 or 3")
+  expect_error(transform_adjust_hue(torch_rand(2, 2, 4, 6), 0.2), "channel values are 1 or 3")
+  # `transform_color_jitter()` reaches the same check through its `hue` argument
+  expect_error(transform_color_jitter(torch_rand(4, 4, 6), hue = 0.2), "channel values are 1 or 3")
+})


### PR DESCRIPTION
The output shapes of several transforms did not match what torchvision for python returns:

* `transform_crop()` clamped the crop to the image instead of padding it with zeros, so the output could be smaller than requested or empty.
* `transform_center_crop()` swapped height and width in the padding branch, so a non-square `size` gave a wrong and sometimes empty shape.
* `transform_rgb_to_grayscale()` dropped the channel dimension instead of returning a single-channel image, which also made `transform_grayscale()` return a wrong shape for batched input.

While adding tests for the hue transformation two further bugs showed up:

* `hsv2rgb()` used `h * 6 - 1` instead of the fractional part of the sector and omitted the saturation in `t`, so converting to HSV and back did not return the original image.
* `transform_adjust_hue()` used `%%`, which is `fmod()` for tensors and keeps the sign of the dividend, so a negative `hue_factor` gave a black image. It now also rejects images that do not have 1 or 3 channels instead of silently dropping the additional ones.