### PR TITLE
 Fix: delete downloaded archives after extraction

### DIFF
--- a/R/dataset-caltech.R
+++ b/R/dataset-caltech.R
@@ -127,10 +127,13 @@ caltech101_dataset <- torch::dataset(
         utils::unzip(dest, exdir = self$root)
       else
         utils::untar(dest, exdir = self$root)
+      fs::file_delete(dest)
 
       extracted <- fs::path(self$root, class(self)[[1]])
-      if (fs::file_exists(fs::path(extracted, "101_ObjectCategories.tar.gz")))
+      if (fs::file_exists(fs::path(extracted, "101_ObjectCategories.tar.gz"))) {
         utils::untar(fs::path(extracted, "101_ObjectCategories.tar.gz"), exdir = extracted)
+        fs::file_delete(fs::path(extracted, "101_ObjectCategories.tar.gz"))
+      }
     }))
 
     cli_inform("Dataset {.cls {class(self)[[1]]}} downloaded and extracted successfully.")

--- a/R/dataset-cifar.R
+++ b/R/dataset-cifar.R
@@ -112,6 +112,7 @@ cifar10_dataset <- torch::dataset(
       runtime_error("Corrupt file! Delete the file in {archive} and try again.")
 
     utils::untar(archive, exdir = self$root)
+    fs::file_delete(archive)
 
     cli_inform("Dataset {.cls {class(self)[[1]]}} downloaded and extracted successfully.")
   },

--- a/R/dataset-coco.R
+++ b/R/dataset-coco.R
@@ -185,6 +185,7 @@ coco_detection_dataset <- torch::dataset(
 
     utils::unzip(ann_zip, exdir = self$data_dir)
     utils::unzip(archive, exdir = self$data_dir)
+    fs::file_delete(c(ann_zip, archive))
 
     cli_inform("Dataset {.cls {class(self)[[1]]}} downloaded and extracted successfully.")
   },

--- a/R/dataset-eurosat.R
+++ b/R/dataset-eurosat.R
@@ -91,6 +91,7 @@ eurosat_dataset <- torch::dataset(
     if (!dir.exists(self$images_dir)) {
       cli_inform("Extracting {.cls {class(self)[[1]]}} archive...")
       utils::unzip(archive, exdir = self$images_dir)
+      fs::file_delete(archive)
       cli_inform("Extraction of {.cls {class(self)[[1]]}} is complete.")
     }
 

--- a/R/dataset-fer.R
+++ b/R/dataset-fer.R
@@ -130,6 +130,7 @@ fer_dataset <- dataset(
     }
 
     untar(archive, exdir = self$root)
+    fs::file_delete(archive)
     cli_inform(
       "Dataset {.cls {class(self)[[1]]}} downloaded and extracted successfully."
     )

--- a/R/dataset-fgvc.R
+++ b/R/dataset-fgvc.R
@@ -172,6 +172,7 @@ fgvc_aircraft_dataset <- dataset(
     }
 
     untar(archive, exdir = self$root)
+    fs::file_delete(archive)
 
     cli_inform("Dataset {.cls {class(self)[[1]]}} downloaded and extracted successfully.")
   }

--- a/R/dataset-flickr.R
+++ b/R/dataset-flickr.R
@@ -145,10 +145,12 @@ flickr8k_caption_dataset <- torch::dataset(
       }
       if (tools::file_ext(archive) == "zip") {
         utils::unzip(archive, exdir = self$raw_folder)
+        fs::file_delete(archive)
       } else if (tools::file_ext(archive) == "gz") {
         tar_path <- sub("\\.gz$", "", archive)
         R.utils::gunzip(archive, tar_path, overwrite = TRUE)
         utils::untar(tar_path, exdir = self$raw_folder)
+        fs::file_delete(tar_path)
       }
     }
 

--- a/R/dataset-flowers.R
+++ b/R/dataset-flowers.R
@@ -140,6 +140,7 @@ flowers102_dataset <- dataset(
     cli_inform("{.cls {class(self)[[1]]}} Extracting images and processing dataset...")
 
     untar(archives[[1]], exdir = self$raw_folder)
+    fs::file_delete(archives[[1]])
     labels <- R.matlab::readMat(archives[[2]])$labels
     setids <- R.matlab::readMat(archives[[3]])
 

--- a/R/dataset-imagenet.R
+++ b/R/dataset-imagenet.R
@@ -48,6 +48,7 @@ tiny_imagenet_dataset <- torch::dataset(
     cli_inform("Processing {.cls {class(self)[[1]]}} ...")
 
     utils::unzip(raw_path, exdir = self$root_path)
+    fs::file_delete(raw_path)
 
     # organize validation images
     val_path <- fs::path_join(c(self$root_path, self$tar_name, "val"))

--- a/R/dataset-lfw.R
+++ b/R/dataset-lfw.R
@@ -156,6 +156,7 @@ lfw_people_dataset <- torch::dataset(
     }
 
     untar(archive, exdir = self$root)
+    fs::file_delete(archive)
 
     if (class(self)[[1]] == "lfw_pairs") {
       for (name in c("pairsDevTrain.txt", "pairsDevTest.txt", "pairs.txt")) {

--- a/R/dataset-mnist.R
+++ b/R/dataset-mnist.R
@@ -448,6 +448,7 @@ emnist_collection <- dataset(
     unzip_dir <- file.path(self$raw_folder, "unzipped")
     fs::dir_create(unzip_dir)
     unzip(archive, exdir = unzip_dir)
+    fs::file_delete(archive)
 
     # unzip second level of archives
     unzipped_root <- fs::dir_ls(unzip_dir, type = "directory", recurse = FALSE)[1]

--- a/R/dataset-oxfordiiitpet.R
+++ b/R/dataset-oxfordiiitpet.R
@@ -123,6 +123,7 @@ oxfordiiitpet_segmentation_dataset <- torch::dataset(
       }
 
       utils::untar(archive, exdir = self$raw_folder)
+      fs::file_delete(archive)
     }
 
     for (split in c("trainval", "test")) {

--- a/R/dataset-pascal.R
+++ b/R/dataset-pascal.R
@@ -179,6 +179,7 @@ pascal_segmentation_dataset <- torch::dataset(
     }
 
     utils::untar(archive, exdir = self$raw_folder)
+    fs::file_delete(archive)
 
     voc_dir <- file.path(self$raw_folder, "VOCdevkit", paste0("VOC", self$year))
     voc_root <- self$raw_folder

--- a/R/dataset-places365.R
+++ b/R/dataset-places365.R
@@ -187,6 +187,7 @@ places365_dataset <- torch::dataset(
         cli_abort("Corrupt file! Delete the file in {archive} and try again.")
 
       utils::untar(archive, exdir = self$base_dir)
+      fs::file_delete(archive)
     }
   },
 

--- a/R/dataset-rf100-peixos.R
+++ b/R/dataset-rf100-peixos.R
@@ -90,6 +90,7 @@ rf100_peixos_segmentation_dataset <- torch::dataset(
     archive_gz <- fs::path(self$data_dir, basename(archive))
     fs::file_copy(archive, archive_gz, overwrite = TRUE)
     utils::untar(archive_gz, exdir = self$data_dir)
+    fs::file_delete(archive_gz)
     # workaround the `--strip-compoents = 8` not widely available
     fs::file_move(
       fs::path_filter(

--- a/R/dataset-vggface2.R
+++ b/R/dataset-vggface2.R
@@ -101,6 +101,7 @@ vggface2_dataset <- torch::dataset(
       fs::file_move(archive[file_id], self$split_file[file_id])
     }
     utils::untar(archive[[1]], exdir = self$raw_folder)
+    fs::file_delete(archive[[1]])
 
     identity_df <- read.csv(archive[[3]], sep = ",", stringsAsFactors = FALSE, strip.white = TRUE)
     identity_df$Class_ID <- trimws(identity_df$Class_ID)
@@ -119,7 +120,8 @@ vggface2_dataset <- torch::dataset(
   },
 
   check_exists = function() {
-    all(fs::file_exists(self$split_file)) &&
+    label_files <- self$split_file[self$resources[self$resources$split %in% c(self$split, "identity"), ]$kind == "label"]
+    all(fs::file_exists(label_files)) &&
       fs::file_exists(file.path(self$processed_folder, glue::glue("{self$split}.rds")))
   },
 


### PR DESCRIPTION
Fixes #99
All dataset  `download()` methods now delete the archive file `(zip/tar.gz)` after it has been extracted, so archives no longer linger in the dataset root directory or the torch cache.

**Question**: wouldn't this make us download the dataset every single time? 