### PR TITLE
Fix: item transform dataset argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,10 @@
 ## Bug fixes and improvements
 
 * `draw_bounding_boxes()` now accepts degenerated bounding-box by default with the `lazy = TRUE` parameter (#400).
+* Detection and segmentation datasets now take an `item_transform` argument, applied to the whole item
+  after `transform` and `target_transform`. Passing a dataset to `item_transform_*()` or
+  `target_transform_rotate()` now adds to those arguments rather than replacing the dataset `.getitem()`
+  method through `unlockBinding()`, which R CMD check flagged as an unsafe call (#399).
 * `vision_make_grid()` now accepts multiple 3D tensors with mixed uint8 and float dtype (#398).
 * `transform_random_affine()` now accepts a bare number for `shear`. It used to widen `degrees`
   instead of `shear`, which left the shear range incomplete and made the sampling fail (#390).

--- a/R/collection-rf100-doc.R
+++ b/R/collection-rf100-doc.R
@@ -12,6 +12,9 @@ NULL
 #' @param download Logical. If TRUE, downloads the dataset if not present at `root`.
 #' @param transform Optional transform function applied to the image.
 #' @param target_transform Optional transform function applied to the target.
+#' @param item_transform Optional transform function applied to the whole item, such as
+#'   [item_transform_rotate()], once `transform` and `target_transform` have been applied.
+#'   It is only used by `.getitem()`, not by the batched `.getbatch()`.
 #'
 #' @return A torch dataset. Each element is a named list with:
 #' - `x`: H x W x 3 array representing the image, auto-oriented and stretched to 640 x 640.
@@ -141,6 +144,7 @@ rf100_document_collection <- torch::dataset(
     dataset, split = c("train", "test", "valid"),
     transform = NULL,
     target_transform = NULL,
+    item_transform = NULL,
     download = FALSE
   ) {
     if (!requireNamespace("arrow", quietly = TRUE)) install.packages("arrow")
@@ -150,6 +154,7 @@ rf100_document_collection <- torch::dataset(
     self$split   <- match.arg(split)
     self$transform <- transform
     self$target_transform <- target_transform
+    self$item_transform <- item_transform
 
     sel <- self$resources$dataset == self$dataset & self$resources$split == self$split
     self$archive_url  <- self$resources$url[sel]
@@ -218,6 +223,8 @@ rf100_document_collection <- torch::dataset(
 
     item <- list(x = x, y = y)
     class(item) <- "image_with_bounding_box"
+    if (!is.null(self$item_transform)) item <- self$item_transform(item)
+
     item
   },
 

--- a/R/dataset-cityscapes.R
+++ b/R/dataset-cityscapes.R
@@ -18,6 +18,8 @@
 #'   Multiple types can be specified (default: "instance").
 #' @param transform Function to transform the input image (default: NULL).
 #' @param target_transform Function to transform the target annotations (default: NULL).
+#' @param item_transform Optional transform function applied to the whole item, such as
+#'   [item_transform_rotate()], once `transform` and `target_transform` have been applied.
 #'
 #' @return A torch dataset object. Each item is a named list:
 #' \itemize{
@@ -155,7 +157,8 @@ cityscapes_dataset <- torch::dataset(
     mode = "fine",
     target_type = "instance",
     transform = NULL,
-    target_transform = NULL
+    target_transform = NULL,
+    item_transform = NULL
   ) {
 
     self$root_path <- root
@@ -164,6 +167,7 @@ cityscapes_dataset <- torch::dataset(
     self$target_type <- target_type
     self$transform <- transform
     self$target_transform <- target_transform
+    self$item_transform <- item_transform
 
     # Validate parameters
     if (!split %in% c("train", "val", "test")) {
@@ -325,6 +329,11 @@ cityscapes_dataset <- torch::dataset(
 
     result <- list(x = x, y = y)
     class(result) <- c("image_with_segmentation_mask", class(result))
+
+    if (!is.null(self$item_transform)) {
+      result <- self$item_transform(result)
+    }
+
     result
   },
 

--- a/R/dataset-classes.R
+++ b/R/dataset-classes.R
@@ -30,6 +30,27 @@ as_segmentation_dataset <- function(self) {
   set_dataset_task_class(self, "segmentation_dataset")
 }
 
+#' Add a transform to a dataset
+#'
+#' Composes `transform` after the one the dataset already holds, so that
+#' transforms applied to a dataset stack in the order they were added. Datasets
+#' are R6 objects, so the field is updated by reference.
+#'
+#' @param self A `dataset` instance, modified in place.
+#' @param field Name of the field holding the transform, either
+#'   `"item_transform"` or `"target_transform"`.
+#' @param transform The function to add.
+#' @keywords internal
+#' @noRd
+add_dataset_transform <- function(self, field, transform) {
+  if (!exists(field, envir = as.environment(self), inherits = FALSE))
+    cli_abort("{.cls {class(self)[[1]]}} has no {.arg {field}} argument, so it cannot be transformed as a whole.")
+
+  previous <- self[[field]]
+  self[[field]] <- if (is.null(previous)) transform else function(x) transform(previous(x))
+  self
+}
+
 #' Coerce a detection target to the `object_detection_target` class
 #'
 #' @param target A list holding at least `boxes`, as built by the `.getitem()`

--- a/R/dataset-coco.R
+++ b/R/dataset-coco.R
@@ -9,6 +9,8 @@
 #' @param download Logical. If TRUE, downloads the dataset if it's not already present in the \code{root} directory.
 #' @param transform Optional transform function applied to the image.
 #' @param target_transform Optional transform function applied to the target (labels, boxes, etc.).
+#' @param item_transform Optional transform function applied to the whole item, such as
+#'   [item_transform_rotate()], once `transform` and `target_transform` have been applied.
 #'
 #' @return An object of class `coco_detection_dataset`. Each item is a list:
 #' - `x`: a `(C, H, W)` array representing the image.
@@ -75,7 +77,8 @@ coco_detection_dataset <- torch::dataset(
     year = c("2017", "2014"),
     download = FALSE,
     transform = NULL,
-    target_transform = NULL
+    target_transform = NULL,
+    item_transform = NULL
   ) {
 
     year <- match.arg(year)
@@ -87,6 +90,7 @@ coco_detection_dataset <- torch::dataset(
     self$split <- split
     self$transform <- transform
     self$target_transform <- target_transform
+    self$item_transform <- item_transform
     self$archive_size <- self$resources[self$resources$year == year & self$resources$split == split & self$resources$content == "image", ]$size
 
     self$data_dir <- fs::path(root, glue::glue("coco{year}"))
@@ -166,6 +170,10 @@ coco_detection_dataset <- torch::dataset(
 
     result <- list(x = x, y = y)
     class(result) <- c("image_with_bounding_box", class(result))
+
+    if (!is.null(self$item_transform)) {
+      result <- self$item_transform(result)
+    }
 
     result
   },
@@ -284,7 +292,8 @@ coco_segmentation_dataset <- torch::dataset(
     year = c("2017", "2014"),
     download = FALSE,
     transform = NULL,
-    target_transform = NULL
+    target_transform = NULL,
+    item_transform = NULL
   ) {
     super$initialize(
       root = root,
@@ -292,7 +301,8 @@ coco_segmentation_dataset <- torch::dataset(
       year = year,
       download = download,
       transform = transform,
-      target_transform = target_transform
+      target_transform = target_transform,
+      item_transform = item_transform
     )
     as_segmentation_dataset(self)
   },
@@ -343,6 +353,11 @@ coco_segmentation_dataset <- torch::dataset(
     if (!is.null(y$masks)) {
       class(result) <- c("image_with_segmentation_mask", class(result))
     }
+
+    if (!is.null(self$item_transform)) {
+      result <- self$item_transform(result)
+    }
+
     result
   }
 )

--- a/R/dataset-oxfordiiitpet.R
+++ b/R/dataset-oxfordiiitpet.R
@@ -8,6 +8,8 @@
 #' @inheritParams mnist_dataset
 #' @param root Character. Root directory where the dataset is stored or will be downloaded to. Files are placed under `root/oxfordiiitpet`.
 #' @param target_type Character. One of \code{"category"} or \code{"binary-category"} (default: \code{"category"}).
+#' @param item_transform Optional transform function applied to the whole item, such as
+#'   [item_transform_rotate()], once `transform` and `target_transform` have been applied.
 #'
 #' @return A torch dataset object \code{oxfordiiitpet_dataset}. Each item is a named list:
 #' - \code{x}: a H x W x 3 integer array representing an RGB image.
@@ -66,12 +68,14 @@ oxfordiiitpet_segmentation_dataset <- torch::dataset(
     target_type = "category",
     transform = NULL,
     target_transform = NULL,
+    item_transform = NULL,
     download = FALSE
   ) {
 
     self$root_path <- root
     self$transform <- transform
     self$target_transform <- target_transform
+    self$item_transform <- item_transform
     self$train <- train
     self$target_type <- target_type
     if (train) {
@@ -206,6 +210,11 @@ oxfordiiitpet_segmentation_dataset <- torch::dataset(
 
     result <- list(x = x, y = y)
     class(result) <- c("image_with_segmentation_mask", class(result))
+
+    if (!is.null(self$item_transform)) {
+      result <- self$item_transform(result)
+    }
+
     result
   },
 

--- a/R/dataset-pascal.R
+++ b/R/dataset-pascal.R
@@ -34,6 +34,8 @@ pascal_voc_classes <- function(class_id = 1:21) {
 #' @param root Character. Root directory where the dataset will be stored under `root/pascal_voc_<year>`.
 #' @param year Character. VOC dataset version to use. One of `"2007"`, `"2008"`, `"2009"`, `"2010"`, `"2011"`, or `"2012"`. Default is `"2012"`.
 #' @param split Character. One of `"train"`, `"val"`, `"trainval"`, or `"test"`. Determines the dataset split. Default is `"train"`.
+#' @param item_transform Optional transform function applied to the whole item, such as
+#'   [item_transform_rotate()], once `transform` and `target_transform` have been applied.
 #'
 #' @return A torch dataset of class \code{pascal_segmentation_dataset}, also
 #' inheriting \code{segmentation_dataset}.
@@ -131,6 +133,7 @@ pascal_segmentation_dataset <- torch::dataset(
     split = "train",
     transform = NULL,
     target_transform = NULL,
+    item_transform = NULL,
     download = FALSE
   ) {
     self$root_path <- root
@@ -138,6 +141,7 @@ pascal_segmentation_dataset <- torch::dataset(
     self$split <-  match.arg(split, choices = c("train", "val", "trainval", "test"))
     self$transform <- transform
     self$target_transform <- target_transform
+    self$item_transform <- item_transform
     if (self$split == "test"){
         self$archive_key <- "test"
     } else {
@@ -246,6 +250,11 @@ pascal_segmentation_dataset <- torch::dataset(
 
     result <- list(x = x, y = y)
     class(result) <- c("image_with_segmentation_mask", class(result))
+
+    if (!is.null(self$item_transform)) {
+      result <- self$item_transform(result)
+    }
+
     result
   },
 
@@ -294,6 +303,7 @@ pascal_detection_dataset <- torch::dataset(
     split = "train",
     transform = NULL,
     target_transform = NULL,
+    item_transform = NULL,
     download = FALSE
   ) {
 
@@ -302,6 +312,7 @@ pascal_detection_dataset <- torch::dataset(
     self$split <- match.arg(split, choices = c("train", "val", "trainval", "test"))
     self$transform <- transform
     self$target_transform <- target_transform
+    self$item_transform <- item_transform
     if (self$split == "test") {
       self$archive_key <- "test"
     } else {
@@ -353,6 +364,11 @@ pascal_detection_dataset <- torch::dataset(
 
     result <- list(x = x, y = y)
     class(result) <- c("image_with_bounding_box", class(result))
+
+    if (!is.null(self$item_transform)) {
+      result <- self$item_transform(result)
+    }
+
     result
   },
 

--- a/R/dataset-rf100-peixos.R
+++ b/R/dataset-rf100-peixos.R
@@ -53,13 +53,15 @@ rf100_peixos_segmentation_dataset <- torch::dataset(
     root = tempdir(),
     download = FALSE,
     transform = NULL,
-    target_transform = NULL
+    target_transform = NULL,
+    item_transform = NULL
   ) {
     self$dataset <- "peixos"
     self$split <- match.arg(split)
     self$root <- fs::path_expand(root)
     self$transform <- transform
     self$target_transform <- target_transform
+    self$item_transform <- item_transform
 
     self$data_dir <- fs::path(self$root, class(self)[[1]])
     self$image_dir <- fs::path(self$data_dir, self$split)
@@ -157,6 +159,11 @@ rf100_peixos_segmentation_dataset <- torch::dataset(
 
     item <- list(x = x, y = y)
     class(item) <- c("image_with_segmentation_mask", class(item))
+
+    if (!is.null(self$item_transform)) {
+      item <- self$item_transform(item)
+    }
+
     item
   }
 )

--- a/R/item-transforms-geometry.R
+++ b/R/item-transforms-geometry.R
@@ -54,14 +54,10 @@ item_transform_rotate <- function(x, angle, interpolation = 2, expand = TRUE, fi
 
 #' @export
 item_transform_rotate.dataset <- function(x, angle, interpolation = 2, expand = TRUE, fill = 0) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_rotate(item, angle = angle, interpolation = interpolation,
                           expand = expand, fill = fill)
-  }
-  x
+  })
 }
 
 #' @export
@@ -259,13 +255,9 @@ item_transform_crop <- function(x, top, left, height, width) {
 
 #' @export
 item_transform_crop.dataset <- function(x, top, left, height, width) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_crop(item, top, left, height, width)
-  }
-  x
+  })
 }
 
 #' @export
@@ -414,13 +406,7 @@ item_transform_hflip <- function(x) {
 
 #' @export
 item_transform_hflip.dataset <- function(x) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
-    item_transform_hflip(item)
-  }
-  x
+  add_dataset_transform(x, "item_transform", item_transform_hflip)
 }
 
 #' @export
@@ -516,13 +502,7 @@ item_transform_vflip <- function(x) {
 
 #' @export
 item_transform_vflip.dataset <- function(x) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
-    item_transform_vflip(item)
-  }
-  x
+  add_dataset_transform(x, "item_transform", item_transform_vflip)
 }
 
 #' @export
@@ -637,13 +617,9 @@ item_transform_center_crop.default <- function(x, size) {
 
 #' @export
 item_transform_center_crop.dataset <- function(x, size) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_center_crop(item, size = size)
-  }
-  x
+  })
 }
 
 #' @export
@@ -875,16 +851,12 @@ item_transform_affine.image_with_segmentation_mask <- function(x, angle = 0,
 item_transform_affine.dataset <- function(x, angle = 0, translate = c(0, 0),
                                           scale = 1, shear = 0, interpolation = 0,
                                           fill = NULL, center = NULL) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_affine(item, angle = angle, translate = translate,
                           scale = scale, shear = shear,
                           interpolation = interpolation, fill = fill,
                           center = center)
-  }
-  x
+  })
 }
 
 #' Pad a dataset item
@@ -932,13 +904,9 @@ item_transform_pad <- function(x, padding, fill = 0, padding_mode = "constant") 
 
 #' @export
 item_transform_pad.dataset <- function(x, padding, fill = 0, padding_mode = "constant") {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_pad(item, padding = padding, fill = fill, padding_mode = padding_mode)
-  }
-  x
+  })
 }
 
 #' @export
@@ -1109,18 +1077,14 @@ item_transform_perspective.default <- function(x, startpoints, endpoints, interp
 #' @export
 item_transform_perspective.dataset <- function(x, startpoints, endpoints, interpolation = 2,
                                                fill = NULL) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_perspective(item,
       startpoints = startpoints,
       endpoints = endpoints,
       interpolation = interpolation,
       fill = fill
     )
-  }
-  x
+  })
 }
 
 #' @export
@@ -1236,13 +1200,9 @@ item_transform_resize.default <- function(x, size, interpolation = 2) {
 
 #' @export
 item_transform_resize.dataset <- function(x, size, interpolation = 2) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_resize(item, size = size, interpolation = interpolation)
-  }
-  x
+  })
 }
 
 #' @export

--- a/R/item-transforms-random-geometry.R
+++ b/R/item-transforms-random-geometry.R
@@ -50,13 +50,9 @@ item_transform_random_horizontal_flip.default <- function(x, p = 0.5) {
 
 #' @export
 item_transform_random_horizontal_flip.dataset <- function(x, p = 0.5) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_random_horizontal_flip(item, p = p)
-  }
-  x
+  })
 }
 
 #' @export
@@ -133,13 +129,9 @@ item_transform_random_vertical_flip.default <- function(x, p = 0.5) {
 
 #' @export
 item_transform_random_vertical_flip.dataset <- function(x, p = 0.5) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_random_vertical_flip(item, p = p)
-  }
-  x
+  })
 }
 
 #' @export
@@ -225,14 +217,10 @@ item_transform_random_resize_crop <- function(x, size, scale = c(0.08, 1),
 item_transform_random_resize_crop.dataset <- function(x, size, scale = c(0.08, 1),
                                                       ratio = c(3 / 4, 4 / 3),
                                                       interpolation = 2) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_random_resize_crop(item, size = size, scale = scale,
                                       ratio = ratio, interpolation = interpolation)
-  }
-  x
+  })
 }
 
 #' @export
@@ -394,15 +382,11 @@ item_transform_random_crop.default <- function(x, size, padding = NULL, pad_if_n
 #' @export
 item_transform_random_crop.dataset <- function(x, size, padding = NULL, pad_if_needed = FALSE,
                                                fill = 0, padding_mode = "constant") {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_random_crop(item, size = size, padding = padding,
                                pad_if_needed = pad_if_needed,
                                fill = fill, padding_mode = padding_mode)
-  }
-  x
+  })
 }
 
 #' @export
@@ -583,16 +567,12 @@ item_transform_random_affine.default <- function(x, degrees, translate = NULL, s
 item_transform_random_affine.dataset <- function(x, degrees, translate = NULL, scale = NULL,
                                                  shear = NULL, interpolation = 0, fill = NULL,
                                                  center = NULL) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_random_affine(item, degrees = degrees, translate = translate,
                                  scale = scale, shear = shear,
                                  interpolation = interpolation, fill = fill,
                                  center = center)
-  }
-  x
+  })
 }
 
 #' @export
@@ -704,15 +684,11 @@ item_transform_random_rotation.dataset <- function(x, degrees, interpolation = 2
   force(expand)
   force(fill)
 
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_random_rotation(item, degrees = degrees,
                                    interpolation = interpolation,
                                    expand = expand, fill = fill)
-  }
-  x
+  })
 }
 
 #' @export
@@ -800,14 +776,10 @@ item_transform_random_erasing.default <- function(x, p = 0.5, scale = c(0.02, 0.
 #' @export
 item_transform_random_erasing.dataset <- function(x, p = 0.5, scale = c(0.02, 0.33), ratio = c(0.3, 3.3),
                                                   value = 0, inplace = FALSE) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_random_erasing(item, p = p, scale = scale, ratio = ratio,
                                   value = value, inplace = inplace)
-  }
-  x
+  })
 }
 
 #' @export
@@ -912,14 +884,10 @@ item_transform_random_perspective.default <- function(x, distortion_scale = 0.5,
 #' @export
 item_transform_random_perspective.dataset <- function(x, distortion_scale = 0.5, p = 0.5,
                                                       interpolation = 2, fill = 0) {
-  original_getitem <- x$.getitem
-  unlockBinding(".getitem", as.environment(x))
-  x$.getitem <- function(index) {
-    item <- original_getitem(index)
+  add_dataset_transform(x, "item_transform", function(item) {
     item_transform_random_perspective(item, distortion_scale = distortion_scale, p = p,
                                       interpolation = interpolation, fill = fill)
-  }
-  x
+  })
 }
 
 #' @export

--- a/R/target-transforms-detection.R
+++ b/R/target-transforms-detection.R
@@ -374,18 +374,9 @@ target_transform_rotate.object_detection_target <- function(target, angle = 0) {
 #' @rdname target_transform_rotate
 #' @export
 target_transform_rotate.dataset <- function(target, angle = 0) {
-  # Capture original getitem in closure
-  original_getitem <- target$.getitem
-  unlockBinding(".getitem", as.environment(target))
-  # Override getitem to apply rotation transform on-the-fly
-  target$.getitem <- function(index) {
-    item <- original_getitem(index)
-    item$y <- target_transform_rotate(item$y, angle = angle)
-    item
-  }
-
-  # Return the modified dataset (copy-on-modify ensures original is preserved)
-  target
+  add_dataset_transform(target, "target_transform", function(y) {
+    target_transform_rotate(y, angle = angle)
+  })
 }
 
 #' Apply an affine transformation to a detection target

--- a/man/cityscapes_dataset.Rd
+++ b/man/cityscapes_dataset.Rd
@@ -10,7 +10,8 @@ cityscapes_dataset(
   mode = "fine",
   target_type = "instance",
   transform = NULL,
-  target_transform = NULL
+  target_transform = NULL,
+  item_transform = NULL
 )
 }
 \arguments{
@@ -33,6 +34,9 @@ Multiple types can be specified (default: "instance").}
 \item{transform}{Function to transform the input image (default: NULL).}
 
 \item{target_transform}{Function to transform the target annotations (default: NULL).}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.}
 }
 \value{
 A torch dataset object. Each item is a named list:

--- a/man/coco_detection_dataset.Rd
+++ b/man/coco_detection_dataset.Rd
@@ -10,7 +10,8 @@ coco_detection_dataset(
   year = c("2017", "2014"),
   download = FALSE,
   transform = NULL,
-  target_transform = NULL
+  target_transform = NULL,
+  item_transform = NULL
 )
 }
 \arguments{
@@ -25,6 +26,9 @@ coco_detection_dataset(
 \item{transform}{Optional transform function applied to the image.}
 
 \item{target_transform}{Optional transform function applied to the target (labels, boxes, etc.).}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.}
 }
 \value{
 An object of class \code{coco_detection_dataset}. Each item is a list:

--- a/man/coco_segmentation_dataset.Rd
+++ b/man/coco_segmentation_dataset.Rd
@@ -10,7 +10,8 @@ coco_segmentation_dataset(
   year = c("2017", "2014"),
   download = FALSE,
   transform = NULL,
-  target_transform = NULL
+  target_transform = NULL,
+  item_transform = NULL
 )
 }
 \arguments{
@@ -26,6 +27,9 @@ coco_segmentation_dataset(
 
 \item{target_transform}{Optional transform function applied to the target.
 Use \code{target_transform_coco_masks} to convert polygon annotations to binary masks.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.}
 }
 \value{
 An object of class \code{coco_segmentation_dataset}. Each item is a list:

--- a/man/oxfordiiitpet_segmentation_dataset.Rd
+++ b/man/oxfordiiitpet_segmentation_dataset.Rd
@@ -10,6 +10,7 @@ oxfordiiitpet_segmentation_dataset(
   target_type = "category",
   transform = NULL,
   target_transform = NULL,
+  item_transform = NULL,
   download = FALSE
 )
 }
@@ -23,6 +24,9 @@ oxfordiiitpet_segmentation_dataset(
 \item{transform}{Optional. A function that takes an image and returns a transformed version (e.g., normalization, cropping).}
 
 \item{target_transform}{Optional. A function that transforms the label.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.}
 
 \item{download}{Logical. If TRUE, downloads the dataset to \verb{root/}. If the dataset is already present, download is skipped.}
 }

--- a/man/pascal_voc_datasets.Rd
+++ b/man/pascal_voc_datasets.Rd
@@ -12,6 +12,7 @@ pascal_segmentation_dataset(
   split = "train",
   transform = NULL,
   target_transform = NULL,
+  item_transform = NULL,
   download = FALSE
 )
 
@@ -21,6 +22,7 @@ pascal_detection_dataset(
   split = "train",
   transform = NULL,
   target_transform = NULL,
+  item_transform = NULL,
   download = FALSE
 )
 }
@@ -34,6 +36,9 @@ pascal_detection_dataset(
 \item{transform}{Optional. A function that takes an image and returns a transformed version (e.g., normalization, cropping).}
 
 \item{target_transform}{Optional. A function that transforms the label.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.}
 
 \item{download}{Logical. If TRUE, downloads the dataset to \verb{root/}. If the dataset is already present, download is skipped.}
 }

--- a/man/rf100_biology_collection.Rd
+++ b/man/rf100_biology_collection.Rd
@@ -9,6 +9,7 @@ rf100_biology_collection(
   split = c("train", "test", "valid"),
   transform = NULL,
   target_transform = NULL,
+  item_transform = NULL,
   download = FALSE
 )
 }
@@ -21,6 +22,10 @@ rf100_biology_collection(
 \item{transform}{Optional transform function applied to the image.}
 
 \item{target_transform}{Optional transform function applied to the target.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.
+It is only used by \code{.getitem()}, not by the batched \code{.getbatch()}.}
 
 \item{download}{Logical. If TRUE, downloads the dataset if not present at \code{root}.}
 }

--- a/man/rf100_damage_collection.Rd
+++ b/man/rf100_damage_collection.Rd
@@ -9,6 +9,7 @@ rf100_damage_collection(
   split = c("train", "test", "valid"),
   transform = NULL,
   target_transform = NULL,
+  item_transform = NULL,
   download = FALSE
 )
 }
@@ -20,6 +21,10 @@ rf100_damage_collection(
 \item{transform}{Optional transform function applied to the image.}
 
 \item{target_transform}{Optional transform function applied to the target.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.
+It is only used by \code{.getitem()}, not by the batched \code{.getbatch()}.}
 
 \item{download}{Logical. If TRUE, downloads the dataset if not present at \code{root}.}
 }

--- a/man/rf100_document_collection.Rd
+++ b/man/rf100_document_collection.Rd
@@ -9,6 +9,7 @@ rf100_document_collection(
   split = c("train", "test", "valid"),
   transform = NULL,
   target_transform = NULL,
+  item_transform = NULL,
   download = FALSE
 )
 }
@@ -21,6 +22,10 @@ rf100_document_collection(
 \item{transform}{Optional transform function applied to the image.}
 
 \item{target_transform}{Optional transform function applied to the target.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.
+It is only used by \code{.getitem()}, not by the batched \code{.getbatch()}.}
 
 \item{download}{Logical. If TRUE, downloads the dataset if not present at \code{root}.}
 }

--- a/man/rf100_infrared_collection.Rd
+++ b/man/rf100_infrared_collection.Rd
@@ -9,6 +9,7 @@ rf100_infrared_collection(
   split = c("train", "test", "valid"),
   transform = NULL,
   target_transform = NULL,
+  item_transform = NULL,
   download = FALSE
 )
 }
@@ -20,6 +21,10 @@ rf100_infrared_collection(
 \item{transform}{Optional transform function applied to the image.}
 
 \item{target_transform}{Optional transform function applied to the target.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.
+It is only used by \code{.getitem()}, not by the batched \code{.getbatch()}.}
 
 \item{download}{Logical. If TRUE, downloads the dataset if not present at \code{root}.}
 }

--- a/man/rf100_medical_collection.Rd
+++ b/man/rf100_medical_collection.Rd
@@ -9,6 +9,7 @@ rf100_medical_collection(
   split = c("train", "test", "valid"),
   transform = NULL,
   target_transform = NULL,
+  item_transform = NULL,
   download = FALSE
 )
 }
@@ -22,6 +23,10 @@ rf100_medical_collection(
 \item{transform}{Optional transform function applied to the image.}
 
 \item{target_transform}{Optional transform function applied to the target.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.
+It is only used by \code{.getitem()}, not by the batched \code{.getbatch()}.}
 
 \item{download}{Logical. If TRUE, downloads the dataset if not present at \code{root}.}
 }

--- a/man/rf100_peixos_segmentation_dataset.Rd
+++ b/man/rf100_peixos_segmentation_dataset.Rd
@@ -9,7 +9,8 @@ rf100_peixos_segmentation_dataset(
   root = tempdir(),
   download = FALSE,
   transform = NULL,
-  target_transform = NULL
+  target_transform = NULL,
+  item_transform = NULL
 )
 }
 \arguments{
@@ -22,6 +23,10 @@ rf100_peixos_segmentation_dataset(
 \item{transform}{Optional transform function applied to the image.}
 
 \item{target_transform}{Optional transform function applied to the target.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.
+It is only used by \code{.getitem()}, not by the batched \code{.getbatch()}.}
 }
 \value{
 A torch dataset. Each element is a named list with:

--- a/man/rf100_underwater_collection.Rd
+++ b/man/rf100_underwater_collection.Rd
@@ -9,6 +9,7 @@ rf100_underwater_collection(
   split = c("train", "test", "valid"),
   transform = NULL,
   target_transform = NULL,
+  item_transform = NULL,
   download = FALSE
 )
 }
@@ -20,6 +21,10 @@ rf100_underwater_collection(
 \item{transform}{Optional transform function applied to the image.}
 
 \item{target_transform}{Optional transform function applied to the target.}
+
+\item{item_transform}{Optional transform function applied to the whole item, such as
+\code{\link[=item_transform_rotate]{item_transform_rotate()}}, once \code{transform} and \code{target_transform} have been applied.
+It is only used by \code{.getitem()}, not by the batched \code{.getbatch()}.}
 
 \item{download}{Logical. If TRUE, downloads the dataset if not present at \code{root}.}
 }

--- a/tests/testthat/helper-torchvision.R
+++ b/tests/testthat/helper-torchvision.R
@@ -147,3 +147,23 @@ make_detection_item <- function(boxes, labels = NULL, image_size = c(100L, 200L)
   class(item) <- c("image_with_bounding_box", "list")
   item
 }
+
+# Toy dataset applying its `item_transform` the way the shipped detection and
+# segmentation datasets do, so that `item_transform_*()` can be tested on a
+# dataset without downloading one.
+toy_item_dataset <- torch::dataset(
+  name = "toy_item_dataset",
+  initialize = function(get_item, size = 1L, item_transform = NULL) {
+    self$get_item <- get_item
+    self$size <- size
+    self$item_transform <- item_transform
+  },
+  .getitem = function(index) {
+    item <- self$get_item(index)
+    if (!is.null(self$item_transform)) {
+      item <- self$item_transform(item)
+    }
+    item
+  },
+  .length = function() self$size
+)

--- a/tests/testthat/test-dataset-classes.R
+++ b/tests/testthat/test-dataset-classes.R
@@ -48,3 +48,27 @@ test_that("coercing an already classed target is a no-op", {
   segmentation <- make_segmentation_item()$y
   expect_identical(class(as_segmentation_target(segmentation)), class(segmentation))
 })
+
+test_that("a dataset transform is composed after the one already held", {
+  ds <- toy_item_dataset(
+    function(index) make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4)),
+    item_transform = item_transform_hflip
+  )
+
+  ds <- item_transform_resize(ds, size = c(50L, 100L))
+  item <- ds$.getitem(1)
+
+  expect_tensor_shape(item$x, c(3, 50, 100))
+  expect_equal_to_r(item$y$boxes[1, ], c((200 - 50) / 2, 10, (200 - 10) / 2, 30))
+})
+
+test_that("a dataset without an item_transform cannot be transformed as a whole", {
+  ds <- torch::dataset(
+    name = "mock_dataset",
+    initialize = function() {},
+    .getitem = function(index) index,
+    .length = function() 1L
+  )()
+
+  expect_error(item_transform_hflip(ds), "has no `item_transform` argument")
+})

--- a/tests/testthat/test-item-transforms-geometry.R
+++ b/tests/testthat/test-item-transforms-geometry.R
@@ -291,14 +291,9 @@ test_that("item_transform_rotate preserves labels for segmentation", {
 })
 
 test_that("item_transform_rotate works on a segmentation dataset", {
-  ds <- dataset(
-    name = "toy_segmentation",
-    initialize = function() {},
-    .getitem = function(index) {
-      make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
+  })
 
   ds <- item_transform_rotate(ds, angle = 90)
   item <- ds$.getitem(1)
@@ -1068,14 +1063,9 @@ test_that("item_transform_affine preserves labels for segmentation", {
 })
 
 test_that("item_transform_affine works on a dataset", {
-  ds <- dataset(
-    name = "toy_detection",
-    initialize = function() {},
-    .getitem = function(index) {
-      make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4), image_size = c(100L, 200L))
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4), image_size = c(100L, 200L))
+  })
 
   ds <- item_transform_affine(ds, translate = c(30, 10))
   item <- ds$.getitem(1)
@@ -1531,17 +1521,11 @@ test_that("item_transform_perspective applies to datasets", {
   sp <- list(c(0, 0), c(199, 0), c(199, 99), c(0, 99))
   ep <- list(c(10, 20), c(209, 20), c(209, 119), c(10, 119))
 
-  ds <- torch::dataset(
-    name = "perspective_test",
-    initialize = function() {
-      self$items <- list(
-        make_detection_item(matrix(c(10, 10, 20, 20), ncol = 4)),
-        make_detection_item(matrix(c(5, 5, 15, 15), ncol = 4))
-      )
-    },
-    .getitem = function(index) self$items[[index]],
-    .length = function() length(self$items)
-  )()
+  items <- list(
+    make_detection_item(matrix(c(10, 10, 20, 20), ncol = 4)),
+    make_detection_item(matrix(c(5, 5, 15, 15), ncol = 4))
+  )
+  ds <- toy_item_dataset(function(index) items[[index]], size = length(items))
 
   transformed <- item_transform_perspective(ds, sp, ep)
 
@@ -1707,14 +1691,9 @@ test_that("item_transform_resize can be composed", {
 })
 
 test_that("item_transform_resize works on detection and segmentation datasets", {
-  ds <- dataset(
-    name = "toy_detection",
-    initialize = function() {},
-    .getitem = function(index) {
-      make_detection_item(matrix(c(120, 70, 180, 130), ncol = 4), image_size = c(200L, 400L))
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_detection_item(matrix(c(120, 70, 180, 130), ncol = 4), image_size = c(200L, 400L))
+  })
 
   ds <- item_transform_resize(ds, size = c(100L, 200L))
   item <- ds$.getitem(1)
@@ -1725,14 +1704,9 @@ test_that("item_transform_resize works on detection and segmentation datasets", 
   expect_equal(item$y$image_height, 100L)
   expect_equal(item$y$image_width, 200L)
 
-  ds <- dataset(
-    name = "toy_segmentation",
-    initialize = function() {},
-    .getitem = function(index) {
-      make_segmentation_item(image_size = c(200L, 400L), num_masks = 2L)
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_segmentation_item(image_size = c(200L, 400L), num_masks = 2L)
+  })
 
   ds <- item_transform_resize(ds, size = c(100L, 200L))
   item <- ds$.getitem(1)

--- a/tests/testthat/test-item-transforms-random-geometry.R
+++ b/tests/testthat/test-item-transforms-random-geometry.R
@@ -402,12 +402,7 @@ test_that("item_transform_random_resize_crop can be composed", {
 
 test_that("item_transform_random_resize_crop works on detection and segmentation datasets", {
   detection_item <- make_detection_item(matrix(c(20, 30, 80, 90), ncol = 4), image_size = c(100L, 200L))
-  ds <- dataset(
-    name = "toy_detection",
-    initialize = function() {},
-    .getitem = function(index) detection_item,
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) detection_item)
 
   ds <- item_transform_random_resize_crop(ds, size = c(50L, 60L))
 
@@ -424,14 +419,9 @@ test_that("item_transform_random_resize_crop works on detection and segmentation
   expect_false(torch_equal(item$x, other$x))
   expect_equal_to_r(detection_item$y$boxes, matrix(c(20, 30, 80, 90), ncol = 4))
 
-  ds <- dataset(
-    name = "toy_segmentation",
-    initialize = function() {},
-    .getitem = function(index) {
-      make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
+  })
 
   ds <- item_transform_random_resize_crop(ds, size = c(50L, 60L))
   item <- ds$.getitem(1)
@@ -559,14 +549,9 @@ test_that("item_transform_random_crop errors when crop is larger than the image"
 })
 
 test_that("item_transform_random_crop works on a detection dataset", {
-  ds <- dataset(
-    name = "toy_detection",
-    initialize = function() {},
-    .getitem = function(index) {
-      make_detection_item(matrix(c(0, 0, 200, 100), ncol = 4), image_size = c(100L, 200L))
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_detection_item(matrix(c(0, 0, 200, 100), ncol = 4), image_size = c(100L, 200L))
+  })
 
   ds <- item_transform_random_crop(ds, size = c(50, 80))
   item <- ds$.getitem(1)
@@ -578,16 +563,11 @@ test_that("item_transform_random_crop works on a detection dataset", {
 })
 
 test_that("item_transform_random_crop works on a segmentation dataset", {
-  ds <- dataset(
-    name = "toy_segmentation",
-    initialize = function() {},
-    .getitem = function(index) {
-      item <- make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
-      item$y$masks$fill_(TRUE)
-      item
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    item <- make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
+    item$y$masks$fill_(TRUE)
+    item
+  })
 
   ds <- item_transform_random_crop(ds, size = c(50, 80))
   item <- ds$.getitem(1)
@@ -745,12 +725,7 @@ test_that("item_transform_random_affine keeps rotated boxes rotated", {
 
 test_that("item_transform_random_affine works on detection and segmentation datasets", {
   detection_item <- make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4), image_size = c(100L, 200L))
-  ds <- dataset(
-    name = "toy_detection",
-    initialize = function() {},
-    .getitem = function(index) detection_item,
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) detection_item)
 
   ds <- item_transform_random_affine(ds, degrees = 30, translate = c(0.1, 0.1))
   item <- ds$.getitem(1)
@@ -762,14 +737,9 @@ test_that("item_transform_random_affine works on detection and segmentation data
   expect_false(torch_equal(item$x, other$x))
   expect_equal_to_r(detection_item$y$boxes, matrix(c(10, 20, 50, 60), ncol = 4))
 
-  ds <- dataset(
-    name = "toy_segmentation",
-    initialize = function() {},
-    .getitem = function(index) {
-      make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
+  })
 
   ds <- item_transform_random_affine(ds, degrees = 30)
   item <- ds$.getitem(1)
@@ -918,12 +888,7 @@ test_that("item_transform_random_rotation accumulates the angle of rotated boxes
 
 test_that("item_transform_random_rotation works on detection and segmentation datasets", {
   detection_item <- make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4), image_size = c(100L, 200L))
-  ds <- dataset(
-    name = "toy_detection",
-    initialize = function() {},
-    .getitem = function(index) detection_item,
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) detection_item)
 
   ds <- item_transform_random_rotation(ds, degrees = 30)
   item <- ds$.getitem(1)
@@ -935,14 +900,9 @@ test_that("item_transform_random_rotation works on detection and segmentation da
   expect_false(torch_equal(item$x, other$x))
   expect_equal_to_r(detection_item$y$boxes, matrix(c(10, 20, 50, 60), ncol = 4))
 
-  ds <- dataset(
-    name = "toy_segmentation",
-    initialize = function() {},
-    .getitem = function(index) {
-      make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L)
+  })
 
   ds <- item_transform_random_rotation(ds, degrees = 30)
   item <- ds$.getitem(1)
@@ -953,12 +913,7 @@ test_that("item_transform_random_rotation works on detection and segmentation da
 
 test_that("item_transform_random_rotation keeps the range given when the dataset was wrapped", {
   detection_item <- make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4), image_size = c(100L, 200L))
-  ds <- dataset(
-    name = "toy_detection",
-    initialize = function() {},
-    .getitem = function(index) detection_item,
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) detection_item)
 
   degrees <- 5
   ds <- item_transform_random_rotation(ds, degrees = degrees)
@@ -1037,14 +992,9 @@ test_that("item_transform_random_erasing works on segmentation items", {
 })
 
 test_that("item_transform_random_erasing works on a dataset", {
-  ds <- dataset(
-    name = "toy_detection",
-    initialize = function() {},
-    .getitem = function(index) {
-      make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4), image_size = c(100L, 200L))
-    },
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4), image_size = c(100L, 200L))
+  })
 
   transformed <- item_transform_random_erasing(ds, p = 0)
   item <- transformed$.getitem(1)
@@ -1106,12 +1056,9 @@ test_that("item_transform_random_perspective detection items", {
   expect_true(torch_equal(item$x, original_img))
   expect_true(torch_equal(item$y$boxes, original_boxes))
 
-  ds <- dataset(
-    name = "toy_detection",
-    initialize = function() {},
-    .getitem = function(index) make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4), image_size = c(100L, 200L)),
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) {
+    make_detection_item(matrix(c(10, 20, 50, 60), ncol = 4), image_size = c(100L, 200L))
+  })
   ds <- item_transform_random_perspective(ds, p = 1)
   ds_item <- ds$.getitem(1)
   expect_s3_class(ds_item, "image_with_bounding_box")
@@ -1143,12 +1090,7 @@ test_that("item_transform_random_perspective segmentation items", {
   result_labels <- item_transform_random_perspective(item, p = 1)
   expect_equal_to_r(result_labels$y$labels, original_labels)
 
-  ds <- dataset(
-    name = "toy_segmentation",
-    initialize = function() {},
-    .getitem = function(index) make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L),
-    .length = function() 1L
-  )()
+  ds <- toy_item_dataset(function(index) make_segmentation_item(image_size = c(100L, 200L), num_masks = 2L))
   ds <- item_transform_random_perspective(ds, p = 1)
   ds_item <- ds$.getitem(1)
   expect_s3_class(ds_item, "image_with_segmentation_mask")


### PR DESCRIPTION
Closes #399 

`R CMD check` flagged 18 `unlockBinding(".getitem", ...)` calls, used by the `item_transform_*()` and `target_transform_rotate()` dataset methods to patch a dataset's `.getitem()` in place.

Detection and segmentation datasets now take an `item_transform` argument,applied to the item after `transform` and
`target_transform`. Passing a dataset to `item_transform_*()` or `target_transform_rotate()` composes onto that argument instead of unlocking the binding, so the pipe form still works. 