### PR TITLE
docs: Classes vignette

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
   Segmentation datasets (`coco_segmentation_dataset()`, `pascal_segmentation_dataset()`, `cityscapes_dataset()`, `oxfordiiitpet_segmentation_dataset()` and `rf100_peixos_segmentation_dataset()`) now inherit the `segmentation_dataset` and `segmentation_target` classes. 
   Target transforms now dispatch on those classes instead of inspecting the target fields: `target_transform_resize()`, `target_transform_rotate()`, `target_transform_affine()` and `target_transform_sahi_crop()` take an `object_detection_target`, and `target_transform_coco_masks()` and `target_transform_trimap_masks()` a `segmentation_target`. A bare list is no longer accepted as a target, so a hand-built one needs its class set (@srishtiii28, #391).
 * Added a "Visualization utilities" article covering `vision_make_grid()`, `draw_bounding_boxes()`, `draw_segmentation_masks()` and `draw_keypoints()` on the output of `model_rfdetr_base()` and `model_fcn_resnet50()` (@srishtiii28, #400).
+* Added a "torchvision classes" vignette sketching what each dataset item class holds: `image_with_bounding_box`, `image_with_rotated_box` and `image_with_segmentation_mask`, their `object_detection_target` and `segmentation_target`, and which transform and drawing functions dispatch on each (@srishtiii28, #396).
 
 ## Bug fixes and improvements
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -8,10 +8,16 @@ development:
 
 navbar:
  structure:
-  left:  [home, examples, reference, news]
+  left:  [home, articles, examples, reference, news]
   right: [github]
  components:
-  articles: ~
+  articles:
+    text: Articles
+    menu:
+      - text: torchvision classes
+        href: articles/torchvision-classes.html
+      - text: RF100 Dataset Catalog
+        href: articles/rf100-datasets.html
   examples:
     text: Examples
     menu:

--- a/vignettes/assets/dataset-item.svg
+++ b/vignettes/assets/dataset-item.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660 330" width="620" height="310" role="img" aria-labelledby="item-title item-desc">
+  <title id="item-title">Anatomy of a dataset item</title>
+  <desc id="item-desc">A deck of cards standing for the items of a dataset. The front card carries an x panel holding the image and a y panel holding the annotations. transform reaches the x panel, target_transform the y panel, and item_transform the card as a whole.</desc>
+  <defs>
+    <marker id="tip" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0 0 L8 4 L0 8 Z" fill="#585858"/>
+    </marker>
+  </defs>
+  <style>
+    .deck { fill: none; stroke: #a0a0a0; stroke-width: 1.2; }
+    .card { fill: #f7ebb0; stroke: #585858; stroke-width: 1.6; }
+    .panel { fill: #ffffff; stroke: #8c8c8c; stroke-width: 1.2; }
+    .glyph { fill: #ececec; stroke: #b8b8b8; stroke-width: 1; }
+    .arrow { fill: none; stroke: #585858; stroke-width: 1.4; marker-end: url(#tip); }
+    .name { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 17px; fill: #3a3a3a; }
+    .note { font-family: "Helvetica Neue", Arial, sans-serif; font-size: 14px; fill: #6f6f6f; }
+  </style>
+
+  <rect class="deck" x="202" y="24" width="450" height="200" rx="4"/>
+  <rect class="deck" x="188" y="36" width="450" height="200" rx="4"/>
+  <rect class="deck" x="174" y="48" width="450" height="200" rx="4"/>
+  <rect class="card" x="160" y="60" width="450" height="200" rx="4"/>
+
+  <text class="name" x="185" y="100">$x</text>
+  <text class="note" x="213" y="100">the image</text>
+  <rect class="panel" x="185" y="112" width="190" height="112"/>
+  <circle class="glyph" cx="216" cy="140" r="11"/>
+  <path class="glyph" d="M196 223 L240 172 L284 223 Z"/>
+  <path class="glyph" d="M258 223 L300 183 L342 223 Z"/>
+
+  <text class="name" x="405" y="100">$y</text>
+  <text class="note" x="433" y="100">the annotations</text>
+  <rect class="panel" x="405" y="112" width="190" height="112"/>
+  <rect class="glyph" x="424" y="134" width="118" height="11" rx="5"/>
+  <rect class="glyph" x="424" y="163" width="150" height="11" rx="5"/>
+  <rect class="glyph" x="424" y="192" width="92" height="11" rx="5"/>
+
+  <text class="name" x="2" y="166">item_transform</text>
+  <path class="arrow" d="M148 160 L156 160"/>
+
+  <text class="name" x="228" y="312">transform</text>
+  <path class="arrow" d="M280 299 L280 233"/>
+
+  <text class="name" x="432" y="312">target_transform</text>
+  <path class="arrow" d="M500 299 L500 233"/>
+</svg>

--- a/vignettes/assets/detection-item.svg
+++ b/vignettes/assets/detection-item.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 300" width="620" height="291" role="img" aria-labelledby="det-title det-desc">
+  <title id="det-title">An image_with_bounding_box item</title>
+  <desc id="det-desc">A card whose x panel holds the image with two boxes drawn on it, and whose y panel lists the fields of an object_detection_target: boxes as an N by 4 tensor in xyxy format, labels, area, iscrowd, image_height and image_width.</desc>
+  <style>
+    .deck { fill: none; stroke: #a0a0a0; stroke-width: 1.2; }
+    .card { fill: #f7ebb0; stroke: #585858; stroke-width: 1.6; }
+    .panel { fill: #ffffff; stroke: #8c8c8c; stroke-width: 1.2; }
+    .glyph { fill: #ececec; stroke: #b8b8b8; stroke-width: 1; }
+    .box { fill: none; stroke: #7a7a7a; stroke-width: 1.8; }
+    .name { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 15px; fill: #3a3a3a; }
+    .value { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 14px; fill: #6f6f6f; }
+    .note { font-family: "Helvetica Neue", Arial, sans-serif; font-size: 14px; fill: #6f6f6f; }
+    .caption { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 17px; fill: #585858; }
+  </style>
+
+  <rect class="deck" x="72" y="24" width="520" height="196" rx="4"/>
+  <rect class="deck" x="58" y="36" width="520" height="196" rx="4"/>
+  <rect class="deck" x="44" y="48" width="520" height="196" rx="4"/>
+  <rect class="card" x="30" y="60" width="520" height="196" rx="4"/>
+
+  <text class="name" x="56" y="99">$x</text>
+  <text class="note" x="82" y="99">the image</text>
+  <rect class="panel" x="56" y="110" width="200" height="126"/>
+  <circle class="glyph" cx="86" cy="138" r="10"/>
+  <path class="glyph" d="M60 235 L106 178 L152 235 Z"/>
+  <path class="glyph" d="M130 235 L170 192 L210 235 Z"/>
+  <rect class="box" x="76" y="170" width="62" height="52"/>
+  <rect class="box" x="148" y="148" width="82" height="66"/>
+
+  <text class="name" x="290" y="99">$y</text>
+  <text class="note" x="316" y="99">an object_detection_target</text>
+
+  <text class="name" x="290" y="124">$boxes</text>
+  <text class="value" x="424" y="124">(N, 4) xyxy</text>
+  <text class="name" x="290" y="145">$labels</text>
+  <text class="value" x="424" y="145">N class names</text>
+  <text class="name" x="290" y="166">$area</text>
+  <text class="value" x="424" y="166">(N)</text>
+  <text class="name" x="290" y="187">$iscrowd</text>
+  <text class="value" x="424" y="187">(N)</text>
+  <text class="name" x="290" y="208">$image_height</text>
+  <text class="value" x="424" y="208">H</text>
+  <text class="name" x="290" y="229">$image_width</text>
+  <text class="value" x="424" y="229">W</text>
+
+  <text class="note" x="290" y="248">only $boxes is guaranteed</text>
+
+  <text class="caption" x="290" y="286" text-anchor="middle">image_with_bounding_box</text>
+</svg>

--- a/vignettes/assets/rotated-box-item.svg
+++ b/vignettes/assets/rotated-box-item.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 300" width="620" height="291" role="img" aria-labelledby="rot-title rot-desc">
+  <title id="rot-title">An image_with_rotated_box item</title>
+  <desc id="rot-desc">A card whose x panel holds the image with two tilted boxes drawn on it, and whose y panel lists the fields of an object_detection_target whose boxes are an N by 5 tensor in xyxyr format, the fifth column holding the rotation angle.</desc>
+  <style>
+    .deck { fill: none; stroke: #a0a0a0; stroke-width: 1.2; }
+    .card { fill: #f7ebb0; stroke: #585858; stroke-width: 1.6; }
+    .panel { fill: #ffffff; stroke: #8c8c8c; stroke-width: 1.2; }
+    .glyph { fill: #ececec; stroke: #b8b8b8; stroke-width: 1; }
+    .box { fill: none; stroke: #7a7a7a; stroke-width: 1.8; }
+    .name { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 15px; fill: #3a3a3a; }
+    .value { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 14px; fill: #6f6f6f; }
+    .note { font-family: "Helvetica Neue", Arial, sans-serif; font-size: 14px; fill: #6f6f6f; }
+    .caption { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 17px; fill: #585858; }
+  </style>
+
+  <rect class="deck" x="72" y="24" width="520" height="196" rx="4"/>
+  <rect class="deck" x="58" y="36" width="520" height="196" rx="4"/>
+  <rect class="deck" x="44" y="48" width="520" height="196" rx="4"/>
+  <rect class="card" x="30" y="60" width="520" height="196" rx="4"/>
+
+  <text class="name" x="56" y="99">$x</text>
+  <text class="note" x="82" y="99">the image</text>
+  <rect class="panel" x="56" y="110" width="200" height="126"/>
+  <circle class="glyph" cx="86" cy="138" r="10"/>
+  <path class="glyph" d="M60 235 L106 178 L152 235 Z"/>
+  <path class="glyph" d="M130 235 L170 192 L210 235 Z"/>
+  <rect class="box" x="76" y="170" width="62" height="52" transform="rotate(-14 107 196)"/>
+  <rect class="box" x="148" y="148" width="82" height="66" transform="rotate(-14 189 181)"/>
+
+  <text class="name" x="290" y="99">$y</text>
+  <text class="note" x="316" y="99">an object_detection_target</text>
+
+  <text class="name" x="290" y="124">$boxes</text>
+  <text class="value" x="424" y="124">(N, 5) xyxyr</text>
+  <text class="name" x="290" y="145">$labels</text>
+  <text class="value" x="424" y="145">N class names</text>
+  <text class="name" x="290" y="166">$area</text>
+  <text class="value" x="424" y="166">(N)</text>
+  <text class="name" x="290" y="187">$iscrowd</text>
+  <text class="value" x="424" y="187">(N)</text>
+  <text class="name" x="290" y="208">$image_height</text>
+  <text class="value" x="424" y="208">H</text>
+  <text class="name" x="290" y="229">$image_width</text>
+  <text class="value" x="424" y="229">W</text>
+
+  <text class="note" x="290" y="248">the fifth column is the angle</text>
+
+  <text class="caption" x="290" y="286" text-anchor="middle">image_with_rotated_box</text>
+</svg>

--- a/vignettes/assets/segmentation-item.svg
+++ b/vignettes/assets/segmentation-item.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 300" width="620" height="291" role="img" aria-labelledby="seg-title seg-desc">
+  <title id="seg-title">An image_with_segmentation_mask item</title>
+  <desc id="seg-desc">A card whose x panel holds the image with two shaded regions drawn on it, and whose y panel lists the fields of a segmentation_target: masks as an N by H by W tensor with one plane per class, labels, and whatever else the dataset annotates.</desc>
+  <style>
+    .deck { fill: none; stroke: #a0a0a0; stroke-width: 1.2; }
+    .card { fill: #f7ebb0; stroke: #585858; stroke-width: 1.6; }
+    .panel { fill: #ffffff; stroke: #8c8c8c; stroke-width: 1.2; }
+    .glyph { fill: #ececec; stroke: #b8b8b8; stroke-width: 1; }
+    .mask { fill: #c9d6cf; fill-opacity: 0.75; stroke: #7a7a7a; stroke-width: 1.4; }
+    .name { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 15px; fill: #3a3a3a; }
+    .value { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 14px; fill: #6f6f6f; }
+    .note { font-family: "Helvetica Neue", Arial, sans-serif; font-size: 14px; fill: #6f6f6f; }
+    .caption { font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace; font-size: 17px; fill: #585858; }
+  </style>
+
+  <rect class="deck" x="72" y="24" width="520" height="196" rx="4"/>
+  <rect class="deck" x="58" y="36" width="520" height="196" rx="4"/>
+  <rect class="deck" x="44" y="48" width="520" height="196" rx="4"/>
+  <rect class="card" x="30" y="60" width="520" height="196" rx="4"/>
+
+  <text class="name" x="56" y="99">$x</text>
+  <text class="note" x="82" y="99">the image</text>
+  <rect class="panel" x="56" y="110" width="200" height="126"/>
+  <circle class="glyph" cx="86" cy="138" r="10"/>
+  <path class="glyph" d="M60 235 L106 178 L152 235 Z"/>
+  <path class="glyph" d="M130 235 L170 192 L210 235 Z"/>
+  <path class="mask" d="M78 218 C72 190 90 166 110 172 C130 178 132 206 122 220 Z"/>
+  <path class="mask" d="M150 212 C146 176 184 152 210 168 C232 182 224 214 204 220 Z"/>
+
+  <text class="name" x="290" y="99">$y</text>
+  <text class="note" x="316" y="99">a segmentation_target</text>
+
+  <text class="name" x="290" y="134">$masks</text>
+  <text class="value" x="400" y="134">(N, H, W)</text>
+  <text class="name" x="290" y="159">$labels</text>
+  <text class="value" x="400" y="159">one per plane</text>
+
+  <text class="note" x="290" y="196">no field is guaranteed: a</text>
+  <text class="note" x="290" y="216">dataset annotates what it</text>
+  <text class="note" x="290" y="236">has, and in its own way</text>
+
+  <text class="caption" x="290" y="286" text-anchor="middle">image_with_segmentation_mask</text>
+</svg>

--- a/vignettes/torchvision-classes.Rmd
+++ b/vignettes/torchvision-classes.Rmd
@@ -1,0 +1,245 @@
+---
+title: "torchvision classes"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{torchvision classes}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+What a torchvision dataset hands back is a plain R list with an S3 class glued
+onto it, and that class is what the rest of the package dispatches on. It decides
+which transform will accept the object, what the object holds once that transform
+has run, and which drawing helper can render it. This article goes through those
+classes and shows what is inside each of them.
+
+The code is not evaluated when the website is built, since most of it needs a
+dataset on disk.
+
+```{r setup}
+library(torchvision)
+library(torch)
+```
+
+## Datasets, items and targets
+
+Indexing a dataset returns an *item*: a list with `x`, the image, and `y`,
+everything the dataset knows about that image. `y` is called the *target*.
+
+![A dataset is a deck of items; each item holds an image in `$x` and its annotations in `$y`.](assets/dataset-item.svg)
+
+A dataset takes up to three transform arguments, and they reach different depths
+of that structure. `transform` is handed `x` alone, `target_transform` is handed
+`y` alone, and `item_transform` is handed the item as a whole, once the other two
+have run. Classification datasets only offer the first two. Detection and
+segmentation datasets offer all three, because an image cannot be rotated or
+cropped without moving its boxes and masks with it.
+
+```{r}
+ds <- coco_detection_dataset(
+  train = FALSE,
+  download = TRUE,
+  transform = transform_to_tensor,
+  item_transform = function(item) item_transform_resize(item, c(480, 640))
+)
+```
+
+`transform_to_tensor` is doing more work there than it looks. A dataset returns
+`x` in whatever form it was read in, which is the `(H, W, 3)` channel-last array
+of `base_loader()` for most of them and a magick image for
+`cityscapes_dataset()`. The item transforms and the drawing helpers all want the
+`(C, H, W)` tensor that torch models take, so a detection or segmentation
+dataset is nearly always built with `transform = transform_to_tensor`.
+
+The dataset itself is classed by task, with `object_detection_dataset` or
+`segmentation_dataset` inserted ahead of `dataset` so that task methods win over
+the generic ones while the dataset keeps its own name first. That class is what
+lets you hand a whole dataset to an item transform:
+
+```{r}
+ds <- item_transform_random_horizontal_flip(ds, p = 0.5)
+```
+
+which composes the flip into the dataset's `item_transform` rather than applying
+it once.
+
+## Classification and caption items
+
+The simplest items carry no class at all. `mnist_dataset()`, `cifar10_dataset()`,
+`eurosat_dataset()` and the other classification datasets return a bare list
+whose `y` is the class index:
+
+```{r}
+mnist <- mnist_dataset(root = tempdir(), download = TRUE, transform = transform_to_tensor)
+str(mnist[1])
+#> List of 2
+#>  $ x:Float [1:1, 1:28, 1:28]
+#>  $ y: int 6
+```
+
+`flickr8k_caption_dataset()` and `flickr30k_caption_dataset()` have the same
+shape, with a character vector of captions in `y`. Nothing dispatches on these
+items: an image transform goes in through `transform`, and there is no geometry
+in the target to keep in sync with it.
+
+## Detection items
+
+`coco_detection_dataset()`, `pascal_detection_dataset()` and the
+`rf100_*_collection()`s give their items the class `image_with_bounding_box` and
+their target the class `object_detection_target`.
+
+![An `image_with_bounding_box` item and the fields of its `object_detection_target`.](assets/detection-item.svg)
+
+| field | contents |
+|---|---|
+| `$boxes` | `(N, 4)` tensor, one row per object, as `(x_min, y_min, x_max, y_max)` in pixels |
+| `$labels` | the class name of each box |
+| `$area` | `(N)` float tensor, the area of each annotation |
+| `$iscrowd` | `(N)` boolean tensor, `TRUE` where the annotation covers a group of objects rather than one |
+| `$image_height`, `$image_width` | the size `x` had when the boxes were read |
+
+Only `$boxes` is guaranteed, since that is the field the class is validated on.
+The rest is whatever the annotations happened to carry: the table above is a
+COCO target, while an RF100 one holds `$boxes`, `$labels` and an `$image_id` and
+nothing else.
+
+`draw_bounding_boxes()` has a method for the item, so it finds `$x`,
+`$y$boxes` and `$y$labels` on its own:
+
+```{r}
+boxed <- draw_bounding_boxes(ds[1])
+tensor_image_browse(boxed)
+```
+
+## Rotated box items
+
+Four numbers per box cannot describe a box that has been turned, so
+`item_transform_rotate()` and `item_transform_affine()` return an
+`image_with_rotated_box` instead of the item they were given:
+
+```{r}
+class(item_transform_rotate(ds[1], angle = 15))
+#> [1] "image_with_rotated_box" "list"
+```
+
+![An `image_with_rotated_box` item: same target fields, but `$boxes` has a fifth column.](assets/rotated-box-item.svg)
+
+The target keeps its `object_detection_target` class and its fields, but
+`$boxes` gains a fifth column holding the accumulated angle in degrees, the
+xyxyr format that `box_xyxy_to_xyxyr()` and `target_transform_rotate()` produce.
+`draw_bounding_boxes()` has a second method for this class which draws each box
+as a polygon through magick rather than as an upright rectangle.
+
+Every item transform has a method for rotated-box items, except
+`item_transform_perspective()`.
+
+## Segmentation items
+
+`coco_segmentation_dataset()`, `pascal_segmentation_dataset()`,
+`cityscapes_dataset()`, `oxfordiiitpet_segmentation_dataset()` and
+`rf100_peixos_segmentation_dataset()` return `image_with_segmentation_mask`
+items whose target is a `segmentation_target`.
+
+![An `image_with_segmentation_mask` item and its `segmentation_target`.](assets/segmentation-item.svg)
+
+No field is required here. Segmentation annotations differ far more between
+datasets than detection ones do, so each dataset passes on what it reads:
+polygons in `$segmentation` for COCO, `$polygon`, `$color`, `$semantic` and
+`$instance` for Cityscapes depending on the requested `target_type`, one-hot
+`$masks` for Oxford-IIIT Pet and Pascal VOC. `$labels` is not uniform either:
+the detection datasets name their classes, while
+`pascal_segmentation_dataset()` numbers the planes of `$masks` that are not
+empty.
+
+What `draw_segmentation_masks()` and the segmentation models want is `$masks`,
+an `(N, H, W)` tensor with one plane per annotated class. Two target transforms
+build it from raw annotations:
+
+| transform | reads |
+|---|---|
+| `target_transform_coco_masks()` | `$segmentation`, the COCO polygons |
+| `target_transform_trimap_masks()` | `$trimap`, the three-value Oxford-IIIT Pet mask |
+
+```{r}
+seg_ds <- coco_segmentation_dataset(
+  train = FALSE,
+  download = TRUE,
+  transform = transform_to_tensor,
+  target_transform = target_transform_coco_masks
+)
+masked <- draw_segmentation_masks(seg_ds[1])
+```
+
+`coco_segmentation_dataset()` only promotes its items to
+`image_with_segmentation_mask` once `$masks` is there, so without that target
+transform they stay `image_with_bounding_box`. `cityscapes_dataset()` has no
+target transform of its own, and its targets have to be turned into `$masks` by
+hand before they can be drawn.
+
+## Which function takes which class
+
+| family | dispatches on | acts on |
+|---|---|---|
+| `transform_*()` | `torch_tensor`, `magick-image`, `array`, `matrix` | the image alone |
+| `target_transform_*()` | `object_detection_target`, `segmentation_target` | the target alone |
+| `item_transform_*()` | `image_with_bounding_box`, `image_with_rotated_box`, `image_with_segmentation_mask`, `dataset` | image and target together |
+| `draw_bounding_boxes()` | `torch_tensor`, `image_with_bounding_box`, `image_with_rotated_box` | draws boxes on the image |
+| `draw_segmentation_masks()` | `torch_tensor`, `image_with_segmentation_mask` | overlays masks on the image |
+
+`draw_keypoints()` is not generic: it takes an image tensor and an `(N, K, 2)`
+keypoint tensor.
+
+Calling any of these on something they have no method for stops with an error
+naming the class it was given, which is usually a sign that a target lost its
+class somewhere along a pipeline.
+
+## Building an item by hand
+
+A bare list is not accepted as a target, so annotations that do not come out of
+a torchvision dataset need their classes set before any of this will look at
+them:
+
+```{r}
+img <- torch_randint(0, 255, size = c(3, 120, 160))$to(dtype = torch_uint8())
+
+y <- list(
+  boxes = torch_tensor(rbind(c(10, 20, 60, 90), c(70, 30, 150, 110)), dtype = torch_float()),
+  labels = c("cat", "dog"),
+  image_height = 120,
+  image_width = 160
+)
+class(y) <- c("object_detection_target", "list")
+
+item <- list(x = img, y = y)
+class(item) <- c("image_with_bounding_box", "list")
+
+str(item)
+#> List of 2
+#>  $ x:Byte [1:3, 1:120, 1:160]
+#>  $ y:List of 4
+#>   ..$ boxes       :Float [1:2, 1:4]
+#>   ..$ labels      : chr [1:2] "cat" "dog"
+#>   ..$ image_height: num 120
+#>   ..$ image_width : num 160
+#>   ..- attr(*, "class")= chr [1:2] "object_detection_target" "list"
+#>  - attr(*, "class")= chr [1:2] "image_with_bounding_box" "list"
+```
+
+A segmentation target is built the same way, with `segmentation_target` and
+`image_with_segmentation_mask`.
+
+## What models return
+
+Model outputs are plain lists and carry no class of their own. The object
+detection models return `$detections`, one element per image of the batch, each
+with `$boxes`, `$labels` and `$scores`; the semantic segmentation models return
+`$out`, the per-class logits. The "Visualization utilities" article covers
+turning either of them into something the drawing helpers can render.


### PR DESCRIPTION
Closes #396.

Adds a vignette that goes through the S3 classes a dataset item can carry and what is inside each one. 